### PR TITLE
CSV injestion redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ Residency Rotation Scheduler (R2S) is a constraint-based optimisation tool that 
 Upload CSVs via the UI (or POST `/api/solve` as multipart form data). Required headers per file:
 
 - Residents: `mcr`, `name`, `resident_year`, `career_blocks_completed`.
-- Resident History: `mcr`, `year`, `month_block`, `career_block`, `posting_code`, `is_current_year`, `is_leave`, `leave_type`.
-- Resident Preferences: `mcr`, `preference_rank`, `posting_code`.
-- SR Preferences: `mcr`, `preference_rank`, `base_posting` (optional file but expected columns if provided). SR bases already completed are dropped at solve time; if the planning year includes career blocks 28–30, elective SR bases must also appear in elective preferences. If a base is chosen as SR, its postings are forbidden outside career blocks 19–30 (except GM, which requires at least three blocks in 19–30).
+- Resident History: `mcr`, `year`, `month_block`, `career_block`, `posting_code`, `is_current_year`, `is_leave`, `leave_type`. Use `is_leave=1` rows to record leave; set `posting_code` only if leave consumes a posting slot.
+- Preferences: `mcr`, `preference_rank`, `posting_code`, `resident_sr_preferences` (optional per row). SR bases already completed are dropped at solve time; if the planning year includes career blocks 28–30, elective SR bases must also appear in elective preferences. If a base is chosen as SR, its postings are forbidden outside career blocks 19–30 (except GM, which requires at least three blocks in 19–30).
 - Postings: `posting_code`, `posting_name`, `posting_type`, `max_residents`, `required_block_duration`.
-- Resident Leaves (optional): `mcr`, `month_block`, `leave_type`, `posting_code` (posting filled when leave consumes a posting slot).
 
 Additional inputs:
 

--- a/client/src/components/ResidentTimetable.tsx
+++ b/client/src/components/ResidentTimetable.tsx
@@ -1,39 +1,39 @@
 import {
-    DndContext,
-    type DragEndEvent,
-    PointerSensor,
-    useSensor,
-    useSensors,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
 } from "@dnd-kit/core";
 import {
-    restrictToFirstScrollableAncestor,
-    restrictToHorizontalAxis,
-    restrictToWindowEdges,
+  restrictToFirstScrollableAncestor,
+  restrictToHorizontalAxis,
+  restrictToWindowEdges,
 } from "@dnd-kit/modifiers";
 import {
-    SortableContext,
-    horizontalListSortingStrategy,
+  SortableContext,
+  horizontalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import React, {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 
 import {
-    CCR_POSTINGS,
-    CORE_REQUIREMENTS,
-    ELECTIVE_REQUIREMENT,
-    monthLabels,
+  CCR_POSTINGS,
+  CORE_REQUIREMENTS,
+  ELECTIVE_REQUIREMENT,
+  monthLabels,
 } from "@/lib/constants";
 import type { AcademicYearRange } from "@/lib/utils";
 import {
-    areSchedulesEqual,
-    cn,
-    formatAcademicYearLabel,
-    moveByInsert,
+  areSchedulesEqual,
+  cn,
+  formatAcademicYearLabel,
+  moveByInsert,
 } from "@/lib/utils";
 import type { Posting, Resident, ResidentHistory, Warning } from "../types";
 
@@ -45,29 +45,29 @@ import ErrorAlert from "./ErrorAlert";
 import SortableBlockCell from "./SortableBlockCell";
 
 import {
-    ChevronLeft,
-    ChevronRight,
-    Info,
-    InfoIcon,
-    Loader2Icon,
+  ChevronLeft,
+  ChevronRight,
+  Info,
+  InfoIcon,
+  Loader2Icon,
 } from "lucide-react";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import {
-    Card,
-    CardAction,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from "./ui/card";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "./ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
@@ -389,15 +389,13 @@ const ResidentTimetable: React.FC<Props> = ({
       setWarnings([]); // clear alerts on successful save
     } catch (err: any) {
       const validationWarnings = err?.response?.data?.warnings;
-      if (
-        Array.isArray(validationWarnings) &&
-        validationWarnings.length > 0
-      ) {
+      if (Array.isArray(validationWarnings) && validationWarnings.length > 0) {
         setWarnings(validationWarnings);
         return;
       }
       const statusCode = err?.response?.status;
-      const msg = err?.response?.data?.detail || "An error occurred while saving.";
+      const msg =
+        err?.response?.data?.detail || "An error occurred while saving.";
       setWarnings([{ code: `ERR ${statusCode}`, description: msg }]);
     } finally {
       setIsSaving(false);
@@ -645,9 +643,7 @@ const ResidentTimetable: React.FC<Props> = ({
           {warnings.length > 0 ? (
             <ErrorAlert
               message="Warnings"
-              description={warnings.map(
-                (v) => `[${v.code}] ${v.description}`
-              )}
+              description={warnings.map((v) => `[${v.code}] ${v.description}`)}
               variantType="destructive"
             />
           ) : (

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -35,9 +35,7 @@ const HomePage: React.FC = () => {
     residents: null,
     resident_history: null,
     resident_preferences: null,
-    resident_sr_preferences: null,
     postings: null,
-    resident_leaves: null,
   });
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -94,9 +92,7 @@ const HomePage: React.FC = () => {
     if (csvFiles.residents) formData.append("residents", csvFiles.residents);
     if (csvFiles.resident_history) formData.append("resident_history", csvFiles.resident_history);
     if (csvFiles.resident_preferences) formData.append("resident_preferences", csvFiles.resident_preferences);
-    if (csvFiles.resident_sr_preferences) formData.append("resident_sr_preferences", csvFiles.resident_sr_preferences);
     if (csvFiles.postings) formData.append("postings", csvFiles.postings);
-    if (csvFiles.resident_leaves) formData.append("resident_leaves", csvFiles.resident_leaves);
     // include weightages and pinned residents
     formData.append("weightages", JSON.stringify(weightages));
     formData.append("pinned_mcrs", JSON.stringify(Array.from(pinnedMcrs.values())));
@@ -210,7 +206,7 @@ const HomePage: React.FC = () => {
       </h1>
 
       {/* Upload Section */}
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
         <FileUpload
           label="Residents CSV"
           onChange={handleFileUpload("residents")}
@@ -224,16 +220,8 @@ const HomePage: React.FC = () => {
           onChange={handleFileUpload("resident_preferences")}
         />
         <FileUpload
-          label="SR Preferences CSV"
-          onChange={handleFileUpload("resident_sr_preferences")}
-        />
-        <FileUpload
           label="Postings CSV"
           onChange={handleFileUpload("postings")}
-        />
-        <FileUpload
-          label="Leave CSV"
-          onChange={handleFileUpload("resident_leaves")}
         />
       </div>
 
@@ -296,7 +284,6 @@ const HomePage: React.FC = () => {
             (!apiResponse &&
               (!csvFiles.residents ||
                 !csvFiles.resident_preferences ||
-                !csvFiles.resident_sr_preferences ||
                 !csvFiles.resident_history ||
                 !csvFiles.postings))
           }

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -317,8 +317,9 @@ const HomePage: React.FC = () => {
           variant="secondary"
           onClick={generateSampleCSV}
           className="cursor-pointer"
+          disabled
         >
-          Download Sample CSV
+          Download Sample CSV (Coming Soon)
         </Button>
       </div>
 

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -106,9 +106,7 @@ export interface CsvFilesState {
   residents: File | null;
   resident_history: File | null;
   resident_preferences: File | null;
-  resident_sr_preferences: File | null;
   postings: File | null;
-  resident_leaves?: File | null;
 }
 
 // generation of sample csv

--- a/server/services/postprocess.py
+++ b/server/services/postprocess.py
@@ -19,7 +19,6 @@ def compute_postprocess(payload: Dict) -> Dict:
     resident_sr_preferences: List[Dict] = payload.get("resident_sr_preferences", [])
     postings: List[Dict] = payload.get("postings", [])
     weightages: Dict = dict(payload.get("weightages", {}) or {})
-    resident_leaves: List[Dict] = payload.get("resident_leaves", [])
 
     solver_solution: Dict = dict(payload.get("solver_solution", {}) or {})
 
@@ -361,7 +360,6 @@ def compute_postprocess(payload: Dict) -> Dict:
         "resident_preferences": resident_preferences,
         "resident_sr_preferences": resident_sr_preferences,
         "postings": postings,
-        "resident_leaves": resident_leaves,
         "weightages": weightages,
         "statistics": {
             "total_residents": len(residents),

--- a/server/services/preprocessing.py
+++ b/server/services/preprocessing.py
@@ -30,13 +30,13 @@ CSV_HEADER_SPECS: Dict[str, Dict[str, Any]] = {
         "aliases": {"is_current_year": ["isCurrentYear"], "is_leave": ["isLeave"]},
     },
     "resident_preferences": {
-        "label": "Resident Preferences CSV",
-        "required": ["mcr", "preference_rank", "posting_code"],
-        "aliases": {},
-    },
-    "resident_sr_preferences": {
-        "label": "SR Preferences CSV",
-        "required": ["mcr", "preference_rank", "base_posting"],
+        "label": "Preferences CSV",
+        "required": [
+            "mcr",
+            "preference_rank",
+            "posting_code",
+            "resident_sr_preferences",
+        ],
         "aliases": {},
     },
     "postings": {
@@ -48,11 +48,6 @@ CSV_HEADER_SPECS: Dict[str, Dict[str, Any]] = {
             "max_residents",
             "required_block_duration",
         ],
-        "aliases": {},
-    },
-    "resident_leaves": {
-        "label": "Resident Leaves CSV",
-        "required": ["mcr", "month_block", "leave_type", "posting_code"],
         "aliases": {},
     },
 }
@@ -278,6 +273,28 @@ def _format_resident_history(records: List[Dict[str, Any]]) -> List[Dict[str, An
     return formatted
 
 
+def _derive_resident_leaves_from_history(
+    resident_history: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    derived: List[Dict[str, Any]] = []
+    for row in resident_history:
+        if not row.get("is_leave") or not row.get("is_current_year"):
+            continue
+        mcr = str(row.get("mcr") or "").strip()
+        month_block = parse_int(row.get("month_block"))
+        if not mcr or month_block is None:
+            continue
+        derived.append(
+            {
+                "mcr": mcr,
+                "month_block": month_block,
+                "leave_type": str(row.get("leave_type") or "").strip(),
+                "posting_code": str(row.get("posting_code") or "").strip(),
+            }
+        )
+    return derived
+
+
 def _format_preferences(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     formatted = []
     for row in records:
@@ -294,10 +311,12 @@ def _format_preferences(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return formatted
 
 
-def _format_sr_preferences(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _format_sr_preferences_from_preferences(
+    records: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
     formatted = []
     for row in records:
-        base_posting = str(row.get("base_posting") or "").strip()
+        base_posting = str(row.get("resident_sr_preferences") or "").strip()
         if not base_posting:
             continue
         formatted.append(
@@ -328,23 +347,6 @@ def _format_postings(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "posting_type": str(row.get("posting_type") or "").strip(),
                 "max_residents": max_residents,
                 "required_block_duration": required_block_duration,
-            }
-        )
-    return formatted
-
-
-def _format_resident_leaves(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    formatted: List[Dict[str, Any]] = []
-    for row in records:
-        month_block = parse_int(row.get("month_block"))
-        if month_block is None:
-            continue
-        formatted.append(
-            {
-                "mcr": str(row.get("mcr") or "").strip(),
-                "month_block": month_block,
-                "leave_type": str(row.get("leave_type") or "").strip(),
-                "posting_code": str(row.get("posting_code") or "").strip(),
             }
         )
     return formatted
@@ -475,9 +477,7 @@ async def preprocess_initial_upload(form: FormData) -> Dict[str, Any]:
     residents_upload = require_upload("residents")
     history_upload = require_upload("resident_history")
     prefs_upload = require_upload("resident_preferences")
-    sr_prefs_upload = require_upload("resident_sr_preferences")
     postings_upload = require_upload("postings")
-    leaves_upload = require_upload("resident_leaves", optional=True)
 
     residents_csv = await _read_csv_upload(
         residents_upload,
@@ -497,39 +497,18 @@ async def preprocess_initial_upload(form: FormData) -> Dict[str, Any]:
         file_label=CSV_HEADER_SPECS["resident_preferences"]["label"],
         header_aliases=CSV_HEADER_SPECS["resident_preferences"]["aliases"],
     )
-    sr_prefs_csv = (
-        await _read_csv_upload(
-            sr_prefs_upload,
-            expected_headers=CSV_HEADER_SPECS["resident_sr_preferences"]["required"],
-            file_label=CSV_HEADER_SPECS["resident_sr_preferences"]["label"],
-            header_aliases=CSV_HEADER_SPECS["resident_sr_preferences"]["aliases"],
-        )
-        if sr_prefs_upload
-        else []
-    )
     postings_csv = await _read_csv_upload(
         postings_upload,
         expected_headers=CSV_HEADER_SPECS["postings"]["required"],
         file_label=CSV_HEADER_SPECS["postings"]["label"],
         header_aliases=CSV_HEADER_SPECS["postings"]["aliases"],
     )
-    leaves_csv = (
-        await _read_csv_upload(
-            leaves_upload,
-            expected_headers=CSV_HEADER_SPECS["resident_leaves"]["required"],
-            file_label=CSV_HEADER_SPECS["resident_leaves"]["label"],
-            header_aliases=CSV_HEADER_SPECS["resident_leaves"]["aliases"],
-        )
-        if leaves_upload
-        else []
-    )
-
     residents = _format_residents(residents_csv)
     resident_history = _format_resident_history(history_csv)
     resident_preferences = _format_preferences(prefs_csv)
-    resident_sr_preferences = _format_sr_preferences(sr_prefs_csv)
+    resident_sr_preferences = _format_sr_preferences_from_preferences(prefs_csv)
     postings = _format_postings(postings_csv)
-    resident_leaves = _format_resident_leaves(leaves_csv)
+    resident_leaves = _derive_resident_leaves_from_history(resident_history)
 
     _validate_no_duplicate_mcrs(residents)
     _validate_no_duplicate_posting_codes(postings)


### PR DESCRIPTION
## Summary

- Consolidate uploads into a single `Preferences` CSV with an extra `resident_sr_preferences` column, removing the standalone `SR preferences` file from the ingest flow and sample data.
- Fold leave data into `resident_history` (`is_leave=1` rows), removing the separate `leaves` CSV from the ingest pipeline and UI.
- Update docs to reflect the new combined preferences file and leave-in-history model.

NOTE: Sample CSV generation has been disabled; refer to issue #13 for development works.

Closes #6 