### PR TITLE
Remove posting name from codebase entirely

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -126,7 +126,7 @@ Can be viewed at http://127.0.0.1:8000/docs
 - Residents: `mcr`, `name`, `resident_year`, `career_blocks_completed`.
 - Resident History: `mcr`, `year`, `month_block` (1–12), `career_block`, `posting_code`, `is_current_year`, `is_leave`, `leave_type` (use `is_leave=1` rows for leave entries).
 - Preferences: `mcr`, `preference_rank`, `posting_code`, `resident_sr_preferences` (optional per row).
-- Postings: `posting_code`, `posting_name`, `posting_type` (`core`/`elective`), `max_residents`, `required_block_duration`.
+- Postings: `posting_code`, `posting_type` (`core`/`elective`), `max_residents`, `required_block_duration`.
 
 ## Data Structure of helpers in `posting_allocator.py`
 
@@ -140,7 +140,6 @@ Refer to `# HELPERS` section of the code in [`server/services/posting_allocator.
   ```
   posting_info[posting_code] = {
     "posting_code": str,
-    "posting_name": str,
     "posting_type": str,
     "max_residents": int,
     "required_block_duration": int
@@ -151,7 +150,6 @@ Refer to `# HELPERS` section of the code in [`server/services/posting_allocator.
   posting_info = {
     "GM (TTSH)": {
         "posting_code": "GM (TTSH)",
-        "posting_name": "General Medicine (TTSH)",
         "posting_type": "core",
         "max_residents": 5,
         "required_block_duration": 1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Upload CSVs via the UI (or POST `/api/solve` as multipart form data). Required h
 - Residents: `mcr`, `name`, `resident_year`, `career_blocks_completed`.
 - Resident History: `mcr`, `year`, `month_block`, `career_block`, `posting_code`, `is_current_year`, `is_leave`, `leave_type`. Use `is_leave=1` rows to record leave; set `posting_code` only if leave consumes a posting slot.
 - Preferences: `mcr`, `preference_rank`, `posting_code`, `resident_sr_preferences` (optional per row). SR bases already completed are dropped at solve time; if the planning year includes career blocks 28–30, elective SR bases must also appear in elective preferences. If a base is chosen as SR, its postings are forbidden outside career blocks 19–30 (except GM, which requires at least three blocks in 19–30).
-- Postings: `posting_code`, `posting_name`, `posting_type`, `max_residents`, `required_block_duration`.
+- Postings: `posting_code`, `posting_type`, `max_residents`, `required_block_duration`.
 
 Additional inputs:
 

--- a/client/src/components/SortableBlockCell.tsx
+++ b/client/src/components/SortableBlockCell.tsx
@@ -117,7 +117,7 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
             <PopoverContent className="w-[260px] p-0">
               <Command>
                 <div className="flex justify-between items-center pr-2">
-                  <CommandInput placeholder="Search by code or name..." />
+                  <CommandInput placeholder="Search by code or type..." />
                   <Button
                     type="button"
                     size="icon"
@@ -160,8 +160,7 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
                     const renderItem = (p: Posting) => (
                       <CommandItem
                         key={p.posting_code}
-                        // include name in value to allow searching by name as well
-                        value={`${p.posting_code} ${p.posting_name}`}
+                        value={`${p.posting_code} ${p.posting_type}`}
                         onSelect={(_) => {
                           onSelectPosting?.(p.posting_code);
                           setOpen(false);
@@ -178,7 +177,9 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
                         <div className="flex flex-col">
                           <span className="font-medium">{p.posting_code}</span>
                           <span className="text-xs text-muted-foreground">
-                            {p.posting_name}
+                            {p.posting_type
+                              ? p.posting_type.toUpperCase()
+                              : "UNKNOWN"}
                           </span>
                         </div>
                       </CommandItem>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -63,7 +63,6 @@ export interface ResidentSrPreference {
 
 export interface Posting {
   posting_code: string;
-  posting_name: string;
   posting_type: string;
   max_residents: number;
   required_block_duration: number;

--- a/server/services/preprocessing.py
+++ b/server/services/preprocessing.py
@@ -43,7 +43,6 @@ CSV_HEADER_SPECS: Dict[str, Dict[str, Any]] = {
         "label": "Postings CSV",
         "required": [
             "posting_code",
-            "posting_name",
             "posting_type",
             "max_residents",
             "required_block_duration",
@@ -343,7 +342,6 @@ def _format_postings(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         formatted.append(
             {
                 "posting_code": str(row.get("posting_code") or "").strip(),
-                "posting_name": str(row.get("posting_name") or "").strip(),
                 "posting_type": str(row.get("posting_type") or "").strip(),
                 "max_residents": max_residents,
                 "required_block_duration": required_block_duration,


### PR DESCRIPTION
Removed from the following areas:
- Sortable block cell component (dropdown when manually assigning)
- Type index
- Preprocessing checks
- Documentation (dev guide and readme)

Closes #30 