### PR TITLE
Support shared balancing quota for GRM (TTSH) and MedComm (TTSH)

### DIFF
--- a/client/src/components/PostingBalancingDeviationSelector.tsx
+++ b/client/src/components/PostingBalancingDeviationSelector.tsx
@@ -35,6 +35,8 @@ interface PostingBalancingDeviationSelectorProps {
 }
 
 const MAX_THRESHOLD = 15;
+const DEFAULT_PREFIXES = ["ED", "GRM", "GM"];
+const DEFAULT_DEVIATION = 4;
 
 const PostingBalancingDeviationSelector: React.FC<
   PostingBalancingDeviationSelectorProps
@@ -55,6 +57,22 @@ const PostingBalancingDeviationSelector: React.FC<
     setValue({ ...value, [selectedPosting]: threshold });
     setSelectedPosting(null);
     setThreshold(1);
+  };
+
+  const handleAddDefaultDeviations = (): void => {
+    const next = { ...value };
+
+    postings.forEach((posting) => {
+      const matchesPrefix = DEFAULT_PREFIXES.some((prefix) =>
+        posting.startsWith(prefix)
+      );
+
+      if (matchesPrefix && !(posting in next)) {
+        next[posting] = DEFAULT_DEVIATION;
+      }
+    });
+
+    setValue(next);
   };
 
   const handleUpdate =
@@ -154,6 +172,21 @@ const PostingBalancingDeviationSelector: React.FC<
               </Button>
             </div>
 
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleAddDefaultDeviations}
+                >
+                  Add defaults for ED / GRM / GM
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Adds deviation = 4 for postings starting with ED, GRM, or GM
+              </TooltipContent>
+            </Tooltip>
+            
             {/* configured list */}
             <div className="flex-1 overflow-y-auto flex flex-col gap-3 mt-4 pr-1">
               {configuredPostings.length === 0 && (

--- a/constraints.md
+++ b/constraints.md
@@ -179,7 +179,6 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 #### HC16 — Balancing within halves and balancing deviation per posting 
 - Within blocks 1-6 and within blocks 7-12, the user can optionally input how much imbalance is allowed between the maximum and minimum number of residents assigned across 6 blocks. 
   - 0 <= (max - min) <= deviation
-  - Set GM, ED, GRM to a high value (eg 4) to ensure a solution.
   - GRM (TTSH) and MedComm (TTSH) share the same balancing deviation and quota.
     - GRM (TTSH) and MedComm (TTSH) are treated as a single balancing group.
     - Balancing is enforced on the sum of individual assignments across the group.

--- a/constraints.md
+++ b/constraints.md
@@ -177,9 +177,12 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
   - 3 MICU + 3 RCCM total (including history)
 
 #### HC16 — Balancing within halves and balancing deviation per posting 
-- Set GM, ED, GRM to a high value (eg 4) to ensure a solution.
 - Within blocks 1-6 and within blocks 7-12, the user can optionally input how much imbalance is allowed between the maximum and minimum number of residents assigned across 6 blocks. 
   - 0 <= (max - min) <= deviation
+  - Set GM, ED, GRM to a high value (eg 4) to ensure a solution.
+  - GRM (TTSH) and MedComm (TTSH) share the same balancing deviation and quota.
+    - GRM (TTSH) and MedComm (TTSH) are treated as a single balancing group.
+    - Balancing is enforced on the sum of individual assignments across the group.
 - Else, by default (no input on the balancing deviation), the imbalance is 0. Resident counts per block are equal within blocks 1–6 and within blocks 7–12 (leave-reserved slots are treated as occupied).
 - `balancing_deviations`
 

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -1618,7 +1618,7 @@ def allocate_timetable(
             "resident_sr_preferences": resident_sr_preferences,
             "postings": postings,
             "weightages": weightages,
-            "balancing_deviations": balancing_deviation,
+            "balancing_deviations": balancing_deviations,
             "resident_leaves": resident_leaves or [],
             "solver_solution": {
                 "entries": solution_entries,

--- a/server/services/postprocess.py
+++ b/server/services/postprocess.py
@@ -12,16 +12,14 @@ def compute_postprocess(payload: Dict) -> Dict:
     ########################################################################
     # INPUT NORMALISATION
     ########################################################################
-
     residents_input: List[Dict] = payload.get("residents", [])
     resident_history_input: List[Dict] = payload.get("resident_history", [])
     resident_preferences: List[Dict] = payload.get("resident_preferences", [])
     resident_sr_preferences: List[Dict] = payload.get("resident_sr_preferences", [])
     postings: List[Dict] = payload.get("postings", [])
     weightages: Dict = dict(payload.get("weightages", {}) or {})
-
+    balancing_deviations: Dict = dict(payload.get("balancing_deviations", {}) or {})
     solver_solution: Dict = dict(payload.get("solver_solution", {}) or {})
-
     # clone resident and history entries for mutation
     residents: List[Dict] = [dict(item) for item in residents_input]
     output_history: List[Dict] = [dict(item) for item in resident_history_input]

--- a/server/utils.py
+++ b/server/utils.py
@@ -302,3 +302,7 @@ MONTH_LABELS = [
     "May",
     "Jun",
 ]
+
+BALANCING_GROUPS = {
+    "GRM+MedComm (TTSH)": ["GRM (TTSH)", "MedComm (TTSH)"],
+}


### PR DESCRIPTION
- Updated HC16 to support shared balancing quotas for GRM (TTSH) and MedComm (TTSH).
- GRM (TTSH) and MedComm (TTSH) are now treated as a single balancing group. 
- Balancing is enforced on the sum of assignments across the group.
- All other postings retain their existing per-posting balancing behaviour
- Changed UI of balancing deviation selector to allow multiselect 
- Closes #5 

