### PR TITLE
Add strict CSV schema validation

### DIFF
--- a/client/src/components/PostingBalancingDeviationSelector.tsx
+++ b/client/src/components/PostingBalancingDeviationSelector.tsx
@@ -41,26 +41,26 @@ const PostingBalancingDeviationSelector: React.FC<
   const configuredPostings = Object.keys(value);
 
   const availablePostings = useMemo(() => {
-    const hasShared =
-      "GRM+MedComm (TTSH)" in value;
-
-    const hasIndividualGRM =
-      "GRM (TTSH)" in value || "MedComm (TTSH)" in value;
+    const hasShared = value.hasOwnProperty("GRM+MedComm (TTSH)");
 
     return postings
       .filter((p) => {
+        // never show already-selected postings
         if (p in value) return false;
 
-        // hide individual GRM/MedComm if shared exists
-        if (hasShared && (p === "GRM (TTSH)" || p === "MedComm (TTSH)"))
+        // never show individual GRM / MedComm
+        if (p === "GRM (TTSH)" || p === "MedComm (TTSH)")
+          return false;
+
+        // if shared already selected, don't show it again
+        if (hasShared && p === "GRM+MedComm (TTSH)")
           return false;
 
         return true;
       })
+      // ensure shared option exists when not selected yet
       .concat(
-        hasShared || hasIndividualGRM
-          ? []
-          : ["GRM+MedComm (TTSH)"]
+        !hasShared ? ["GRM+MedComm (TTSH)"] : []
       )
       .sort();
   }, [postings, value]);

--- a/client/src/lib/csvValidators.ts
+++ b/client/src/lib/csvValidators.ts
@@ -1,0 +1,29 @@
+type ValidationResult = { ok: true } | { ok: false; error: string };
+
+const isInt = (v: any) => Number.isInteger(Number(v));
+
+export const validators = {
+    residents: (row: any, i: number): ValidationResult => {
+        if (!row.mcr?.startsWith("M")) return { ok: false, error: `Row ${i}: mcr must start with 'M'` };
+        if (typeof row.name !== "string") return { ok: false, error: `Row ${i}: name must be string` };
+        if (![1, 2, 3].includes(Number(row.resident_year)))
+            return { ok: false, error: `Row ${i}: resident_year must be 1, 2, or 3` };
+        if (!isInt(row.career_blocks_completed) || Number(row.career_blocks_completed) < 0)
+            return { ok: false, error: `Row ${i}: career_blocks_completed must be >= 0` };
+            return { ok: true };
+    },
+
+    postings: (row: any, i: number): ValidationResult => {
+        if (!row.posting_code?.includes("(") || !row.posting_code?.includes(")"))
+            return { ok: false, error: `Row ${i}: posting_code must contain ()` };
+        if (!row.posting_name?.includes("(") || !row.posting_name?.includes(")"))
+            return { ok: false, error: `Row ${i}: posting_name must contain ()` };
+        if (!["core", "elective"].includes(row.posting_type))
+            return { ok: false, error: `Row ${i}: posting_type must be core or elective` };
+        if (!isInt(row.max_residents) || Number(row.max_residents) < 0)
+            return { ok: false, error: `Row ${i}: max_residents must be >= 0` };
+        if (!isInt(row.required_block_duration) || Number(row.required_block_duration) < 1)
+            return { ok: false, error: `Row ${i}: required_block_duration must be >= 1` };
+            return { ok: true };
+    },
+};

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -19,6 +19,7 @@ import ResidentDropdown from "../components/ResidentDropdown";
 import ResidentTimetable from "../components/ResidentTimetable";
 import WeightageSelector from "../components/WeightageSelector";
 import { generateSampleCSV } from "../lib/generateSampleCSV";
+import { validators } from "../lib/csvValidators";
 
 import {
   cn,
@@ -83,31 +84,46 @@ const HomePage: React.FC = () => {
         return;
       }
 
-      setCsvFiles((prev) => ({ ...prev, [fileType]: file }));
       setError(null);
       setApiResponse(null);
 
-      if (fileType === "postings") {
-        Papa.parse(file, {
-          header: true,
-          skipEmptyLines: true,
-          complete: (results: { data: any[]; }) => {
-            const codes = Array.from(
-              new Set(
-                results.data
-                  .map((row: any) => row.posting_code)
-                  .filter(Boolean)
-              )
-            );
+      Papa.parse(file, {
+        header: true,
+        skipEmptyLines: true,
+        worker: true, // for performance
+        complete: (results: { data: any[] }) => {
+          // validate rows 
+          if (validators[fileType as keyof typeof validators]) {
+            for (let i = 0; i < results.data.length; i++) {
+              const res = validators[fileType as keyof typeof validators](
+                results.data[i],
+                i + 2 // CSV header offset
+              );
+              if (!res.ok) {
+                setError(res.error);
+                return;
+              }
+            }
+          }
 
-            setPostingCodes(codes);
-          },
-          error: () => {
-            setError("Failed to parse postings CSV.");
-          },
-        });
-      }
-    };
+        // extract posting codes
+        if (fileType === "postings") {
+          const codes = Array.from(
+            new Set(
+              results.data
+                .map((row: any) => row.posting_code)
+                .filter(Boolean)
+            )
+          );
+          setPostingCodes(codes);
+        }
+
+        // save file only after validation
+        setCsvFiles((prev) => ({ ...prev, [fileType]: file }));
+      },
+      error: () => setError(`Failed to parse ${fileType} CSV.`),
+    });
+  };
 
   const handleProcessFiles = async () => {
     setIsProcessing(true);
@@ -116,10 +132,10 @@ const HomePage: React.FC = () => {
     const formData = new FormData();
 
     // if CSVs present, always include them, else omit
-    if (csvFiles.residents) formData.append("residents", csvFiles.residents);
-    if (csvFiles.resident_history) formData.append("resident_history", csvFiles.resident_history);
-    if (csvFiles.resident_preferences) formData.append("resident_preferences", csvFiles.resident_preferences);
-    if (csvFiles.postings) formData.append("postings", csvFiles.postings);
+    Object.entries(csvFiles).forEach(([key, file]) => {
+      if (file) formData.append(key, file);
+    })
+    
     // include weightages and pinned residents
     formData.append("weightages", JSON.stringify(weightages));
     formData.append("balancing_deviations", JSON.stringify(postingDeviation));

--- a/server/services/preprocessing.py
+++ b/server/services/preprocessing.py
@@ -74,7 +74,6 @@ SR_PREFERENCE_ALIASES: Dict[str, str] = {
     "Gap Year": "",
 }
 
-
 def _normalise_sr_preference(value: Any) -> str:
     cleaned = str(value or "").strip()
     if not cleaned:
@@ -268,19 +267,170 @@ async def _read_csv_upload(
             status_code=400, detail=f"[{file_label}] Invalid CSV format: {exc}"
         ) from exc
 
+########################################################################
+# Helpers for validating columns in each CSV type
+########################################################################
+def _require(condition: bool, message: str, label: str) -> None:
+    if not condition:
+        raise HTTPException(
+            status_code=400,
+            detail=f"[{label}] {message}",
+        )
+
+def _require_int_in(
+    value: Any, allowed: List[int], field: str, label: str
+) -> int:
+    parsed = parse_int(value)
+    _require(parsed in allowed, f"{field} must be one of {allowed}", label)
+    return parsed
+
+def _require_int_min(
+    value: Any, min_value: int, field: str, label: str
+) -> int:
+    parsed = parse_int(value)
+    _require(
+        parsed is not None and parsed >= min_value,
+        f"{field} must be ≥ {min_value}",
+        label,
+    )
+    return parsed
+
+def _validate_residents_strict(residents: List[Dict[str, Any]]) -> None:
+    label = CSV_HEADER_SPECS["residents"]["label"]
+
+    for idx, r in enumerate(residents, start=1):
+        mcr = str(r.get("mcr") or "").strip()
+        _require(mcr.startswith("M"), f"Row {idx}: mcr must start with 'M'", label)
+        _require(
+            isinstance(r.get("name"), str) and r["name"].strip(),
+            f"Row {idx}: name must be a non-empty string",
+            label,
+        )
+        _require_int_in(
+            r.get("resident_year"),
+            [1, 2, 3],
+            f"Row {idx}: resident_year",
+            label,
+        )
+        _require_int_min(
+            r.get("career_blocks_completed"),
+            0,
+            f"Row {idx}: career_blocks_completed",
+            label,
+        )
+
+def _validate_postings_strict(postings: List[Dict[str, Any]]) -> None:
+    label = CSV_HEADER_SPECS["postings"]["label"]
+
+    for idx, p in enumerate(postings, start=1):
+        code = str(p.get("posting_code") or "").strip()
+        _require(
+            "(" in code and ")" in code,
+            f"Row {idx}: posting_code must contain '(' and ')'",
+            label,
+        )
+        _require(
+            p.get("posting_type") in {"core", "elective"},
+            f"Row {idx}: posting_type must be 'core' or 'elective'",
+            label,
+        )
+        _require_int_min(
+            p.get("max_residents"),
+            0,
+            f"Row {idx}: max_residents",
+            label,
+        )
+        _require_int_min(
+            p.get("required_block_duration"),
+            1,
+            f"Row {idx}: required_block_duration",
+            label,
+        )
+
+def _validate_preferences_strict(
+    prefs: List[Dict[str, Any]], posting_codes: set
+) -> None:
+    label = CSV_HEADER_SPECS["resident_preferences"]["label"]
+
+    for idx, r in enumerate(prefs, start=1):
+        mcr = str(r.get("mcr") or "").strip()
+        _require(mcr.startswith("M"), f"Row {idx}: invalid mcr", label)
+        _require_int_in(
+            r.get("preference_rank"),
+            [1, 2, 3, 4, 5],
+            f"Row {idx}: preference_rank",
+            label,
+        )
+        posting_code = str(r.get("posting_code") or "").strip()
+        if posting_code:
+            _require(
+                posting_code in posting_codes,
+                f"Row {idx}: posting_code '{posting_code}' not found in postings CSV",
+                label,
+            )
+
+def _validate_resident_history_strict(
+    history: List[Dict[str, Any]], posting_codes: set
+) -> None:
+    label = CSV_HEADER_SPECS["resident_history"]["label"]
+
+    for idx, r in enumerate(history, start=1):
+        mcr = str(r.get("mcr") or "").strip()
+        _require(mcr.startswith("M"), f"Row {idx}: invalid mcr", label)
+        _require_int_min(r.get("year"), 0, f"Row {idx}: year", label)
+        month = _require_int_in(
+            r.get("month_block"),
+            list(range(1, 13)),
+            f"Row {idx}: month_block",
+            label,
+        )
+        _require_int_in(
+            r.get("career_block"),
+            list(range(0, 37)),
+            f"Row {idx}: career_block",
+            label,
+        )
+        posting_code = str(r.get("posting_code") or "").strip()
+        is_leave = r.get("is_leave")
+
+        # Allow empty posting_code if on leave; otherwise must exist in posting_codes
+        if posting_code:
+            _require(
+                posting_code in posting_codes,
+                f"Row {idx}: posting_code '{posting_code}' not found in postings CSV",
+                label,
+            )
+        elif not posting_code and is_leave != 1:
+            _require(
+                False,
+                f"Row {idx}: posting_code cannot be empty when not on leave",
+                label,
+            )
+            
+        leave_type = str(r.get("leave_type") or "").strip()
+        if is_leave == 0:
+            _require(
+                leave_type == "0" or not leave_type,
+                f"Row {idx}: leave_type must be 0 when is_leave=0",
+                label,
+            )
+        else:
+            _require(
+                leave_type in {"LOA", "MOPEX", "NS"},
+                f"Row {idx}: leave_type must be LOA or MOPEX or NS",
+                label,
+            )
 
 ########################################################################
 # Formatting functions for each CSV type
 ########################################################################
-
-
 def _format_residents(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     formatted = []
     for row in records:
         career_blocks = parse_int(
             row.get("career_blocks_completed") or row.get("careerBlocksCompleted")
         )
-        resident_year = parse_int(row.get("resident_year")) or 0
+        resident_year = parse_int(row.get("resident_year"))
         formatted.append(
             {
                 "mcr": str(row.get("mcr") or "").strip(),
@@ -358,7 +508,7 @@ def _format_preferences(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         formatted.append(
             {
                 "mcr": str(row.get("mcr") or "").strip(),
-                "preference_rank": parse_int(row.get("preference_rank")) or 0,
+                "preference_rank": parse_int(row.get("preference_rank")),
                 "posting_code": posting_code,
             }
         )
@@ -562,6 +712,12 @@ async def preprocess_initial_upload(form: FormData) -> Dict[str, Any]:
     resident_sr_preferences = _format_sr_preferences_from_preferences(prefs_csv)
     postings = _format_postings(postings_csv)
     resident_leaves = _derive_resident_leaves_from_history(resident_history)
+
+    posting_codes = {p["posting_code"] for p in postings if p["posting_code"]}
+    _validate_residents_strict(residents)
+    _validate_postings_strict(postings)
+    _validate_preferences_strict(resident_preferences, posting_codes)
+    _validate_resident_history_strict(resident_history, posting_codes)
 
     _validate_no_duplicate_mcrs(residents)
     _validate_no_duplicate_posting_codes(postings)


### PR DESCRIPTION
#### Features added 
- Added strict validation functions for each CSV type to verify required columns are present, enforce data type constraints (e.g. integers, booleans), validate value ranges and allowed enums
- Added row-specific error messages (e.g. Row X: invalid month_block) to make CSV issues easy to diagnose
- Added a check to ensure that in `resident_history` CSV file, the `posting_code` (if any) should be found in `posting_code` from `postings` CSV file. It should not be a leave_type or random date.
- Closes #41
- Examples: 
<img width="1415" height="720" alt="Screenshot 2026-01-02 at 10 44 04" src="https://github.com/user-attachments/assets/ae138933-c246-4229-9caf-319f42df5876" />
<img width="1198" height="669" alt="Screenshot 2026-01-02 at 13 52 49" src="https://github.com/user-attachments/assets/db797011-4058-4205-bca6-b484f5e15109" />
<img width="1196" height="664" alt="Screenshot 2026-01-02 at 13 58 42" src="https://github.com/user-attachments/assets/ae675b72-7ad0-4de7-8e62-32629c3e3a16" />

#### Why this change is needed
- Prevents malformed or inconsistent CSV uploads from reaching the scheduling logic.
- Makes CSV errors explicit, actionable, and user-friendly, instead of failing silently or producing incorrect schedules.

#### Other bug fixes 
- In the balancing deviation dropdown, show GRM and Medcomm together, without their individual postings
- Closes #42 