### PR TITLE
fix: 0 `max_residents` to be treated as no quota

### DIFF
--- a/constraints.md
+++ b/constraints.md
@@ -96,6 +96,7 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 #### HC2 — Posting capacity
 
 - Per-block headcount ≤ `max_residents` minus any slots reserved for leave.
+  - NOTE: If `max_residents=0` in `postings.csv`, it is treated as no quota limit on the maximum number of residents in that posting.
 - `available_capacity = max_residents - leave_reserved_slots`
 - `sum(x[r["mcr"]][p][b] for r in residents) <= available_capacity`
 

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -374,6 +374,18 @@ def allocate_timetable(
         for b in blocks:
             # leaves with posting_code reserve capacity; available slots shrink by that amount
             leave_reserved_slots = leave_quota_usage.get(p, {}).get(b, 0)
+
+            if max_residents == 0:
+                # No quota limit → skip the constraint
+                if leave_reserved_slots:
+                    logger.info(
+                        "No quota for posting %s, but %d slot(s) reserved for leave on block %s",
+                        p,
+                        leave_reserved_slots,
+                        b,
+                    )
+                continue
+
             available_capacity = max_residents - leave_reserved_slots
             if available_capacity < 0:
                 logger.warning(
@@ -874,7 +886,11 @@ def allocate_timetable(
         max_residents = sum(posting_info[p]["max_residents"] for p in postings_in_group) 
 
         # ensure balancing deviation is within posting capacity
-        delta = max(0, min(balancing_deviation, max_residents))
+        if max_residents == 0:
+            # 0 means unlimited capacity → do not cap deviation
+            delta = max(0, balancing_deviation)
+        else:
+            delta = max(0, min(balancing_deviation, max_residents))
 
         # update balancing_deviations if delta is non-zero
         if delta > 0:

--- a/server/services/postprocess.py
+++ b/server/services/postprocess.py
@@ -324,16 +324,20 @@ def compute_postprocess(payload: Dict) -> Dict:
             b = int(a.get("month_block", 0))
             if 1 <= b <= 12:
                 block_filled[b] += 1
-        capacity = int(pinfo.get("max_residents", 0))
-        util_per_block = [
-            {
-                "month_block": block,
-                "filled": count,
-                "capacity": capacity,
-                "is_over_capacity": count > capacity,
-            }
-            for block, count in block_filled.items()
-        ]
+
+        util_per_block = []
+        for block, count in block_filled.items():
+            cap = posting_info[posting_code]["max_residents"]
+            effective_capacity = count if cap == 0 else cap
+            util_per_block.append(
+                {
+                    "month_block": block,
+                    "filled": count,
+                    "capacity": effective_capacity,
+                    "is_over_capacity": count > effective_capacity,
+                }
+            )
+
         posting_util.append(
             {"posting_code": posting_code, "util_per_block": util_per_block}
         )

--- a/server/services/validate.py
+++ b/server/services/validate.py
@@ -277,6 +277,11 @@ def validate_assignment(payload: Dict[str, Any]) -> Dict[str, Any]:
             cap.setdefault(p, {})[b] = cap.get(p, {}).get(b, 0) + 1
         for p_code, by_b in cap.items():
             max_r = int(posting_info.get(p_code, {}).get("max_residents", 0))
+            
+            # 0 means unlimited → skip capacity validation
+            if max_r == 0:
+                continue
+
             for b, filled in by_b.items():
                 if filled > max_r:
                     add_warning(


### PR DESCRIPTION
- Fixed the interpretation of `max_residents=0` to allow the solver to assign any number of residents to the posting, eg `MedComm (TTSH)` and `RCCM (KTPH)` 
- Closes #49 

<img width="1043" height="231" alt="Screenshot 2026-01-07 at 16 26 16" src="https://github.com/user-attachments/assets/03129ba8-e3d9-4b66-9c68-23992edaa74a" />
