### PR TITLE
fix: HC5 causing infeasibility

### DIFF
--- a/constraints.md
+++ b/constraints.md
@@ -26,6 +26,10 @@ Postings include:
 - **Med Onco**: Medical Oncology
 - **PMD**: Palliative Medicine
 - **RAI**: Rheumatology and Immunology
+- **Rehab**: Rehabilitation
+- **Renal**: Renal Medicine
+- **NL**: Neurology
+- **Derm**: Dermatology
 
 ## Overview of posting assignment
 
@@ -117,7 +121,15 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 #### HC5 — Core caps (per resident)
 
 - Do not exceed base core requirements.
-- If already met historically, block further assignments of that base.
+  - `GM` and `GRM` can exceed base requirements if the resident already completed `MedComm (TTSH)` in the past or are assigned `MedComm (TTSH)` in any block this year.
+  | Scenario                | medcomm_flag | GM max | GRM max |
+  | ----------------------- | ------------ | ------ | ------- |
+  | No MedComm              | 0            | 6      | 2       |
+  | MedComm done / assigned | 1            | 12     | 3       |
+
+- If already met historically, block further assignments of that base. 
+  - Exception: `GM` and `GRM` can exceed base requirements (to max of 12 or 3 respectively) if the resident already completed `MedComm (TTSH)` in the past or are assigned `MedComm (TTSH)` in any block this year.
+- Implies that if a resident has already exceeded the `GM` / `GRM` base cap and has not done `MedComm` historically, then the solver MUST assign `MedComm`.
 
 #### HC6 — Elective repetition
 

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -485,11 +485,65 @@ def allocate_timetable(
             model.Add(ccr_runs == 0)
 
     # Hard Constraint 5: Ensure core postings are not over-assigned to each resident
+    # # HC5 only enforces simple caps. MICU and RCCM are governed exclusively by HC15.
+    # HC5_SIMPLE_CORES = {"CVM", "ED", "NL"}
+    HC5_GM_GRM = {"GM", "GRM"}
+
+    GM_GRM_CAPS = {
+        0: {"GM": CORE_REQUIREMENTS["GM"], "GRM": CORE_REQUIREMENTS["GRM"]},
+        1: {"GM": 12, "GRM": 3},  # with MedComm
+    }
+
+    needs_medcomm = {}
+    medcomm_flag = {}
+
     for resident in residents:
         mcr = resident["mcr"]
         resident_progress = posting_progress.get(mcr, {})
 
-        # get core blocks completed
+        core_completed = get_core_blocks_completed(
+            resident_progress, posting_info
+        )
+
+        # Detect residents who already exceeded base GM/GRM caps
+        needs_medcomm[mcr] = (
+            core_completed.get("GM", 0) > GM_GRM_CAPS[0]["GM"]
+            or core_completed.get("GRM", 0) > GM_GRM_CAPS[0]["GRM"]
+        )
+
+        # MedComm flag: true if completed historically or assigned this year
+        medcomm_flag[mcr] = model.NewBoolVar(f"medcomm_flag[{mcr}]")
+
+        if needs_medcomm[mcr]:
+            # Must unlock higher GM/GRM caps
+            model.Add(medcomm_flag[mcr] == 1)
+
+        # Historical MedComm completion
+        medcomm_done_historically = int(
+            resident_progress
+            .get("MedComm (TTSH)", {})
+            .get("is_completed", False)
+        )
+
+        if medcomm_done_historically:
+            model.Add(medcomm_flag[mcr] == 1)
+        else:
+            medcomm_assigned = sum(
+                x[mcr]["MedComm (TTSH)"][b] for b in blocks
+            )
+
+            # medcomm_flag == 1  ⇔  at least one MedComm assigned
+            model.Add(medcomm_assigned >= medcomm_flag[mcr])
+            model.Add(medcomm_assigned >= 1).OnlyEnforceIf(medcomm_flag[mcr])
+
+    for resident in residents:
+        mcr = resident["mcr"]
+        resident_progress = posting_progress.get(mcr, {})
+
+        # Flag: MedComm completed historically OR assigned in any block this year
+        flag = medcomm_flag[mcr]
+
+        # get core blocks completed historically
         core_blocks_completed_map = get_core_blocks_completed(
             resident_progress, posting_info
         )
@@ -504,10 +558,33 @@ def allocate_timetable(
                 for b in blocks
             )
 
-            if blocks_completed >= required_blocks:
-                model.Add(assigned_blocks == 0)
-            else:
-                model.Add(blocks_completed + assigned_blocks <= required_blocks)
+            # extended caps for GM / GRM if medcomm present
+            if base_posting in HC5_GM_GRM:
+                cap_no_medcomm = GM_GRM_CAPS[0][base_posting]
+                cap_with_medcomm = GM_GRM_CAPS[1][base_posting]
+
+                model.Add(
+                    blocks_completed + assigned_blocks <= cap_no_medcomm
+                ).OnlyEnforceIf(flag.Not())
+                model.Add(
+                    blocks_completed + assigned_blocks <= cap_with_medcomm
+                ).OnlyEnforceIf(flag)
+
+            # simple capped cores
+            elif base_posting in HC5_SIMPLE_CORES:
+                if blocks_completed >= required_blocks:
+                    # Requirement already met → block further assignment
+                    model.Add(assigned_blocks == 0)
+                else:
+                    model.Add(
+                        blocks_completed + assigned_blocks <= required_blocks
+                    )
+
+            # MICU / RCCM
+            # else:
+            #     # Intentionally not capped here.
+            #     # Governed exclusively by HC15 (packs, stages, contiguity).
+            #     pass
 
     # Hard Constraint 6: Prevent residents from repeating the same elective regardless of hospital
     for resident in residents:

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -485,8 +485,8 @@ def allocate_timetable(
             model.Add(ccr_runs == 0)
 
     # Hard Constraint 5: Ensure core postings are not over-assigned to each resident
-    # # HC5 only enforces simple caps. MICU and RCCM are governed exclusively by HC15.
-    # HC5_SIMPLE_CORES = {"CVM", "ED", "NL"}
+    # HC5 only enforces simple caps. MICU and RCCM are governed exclusively by HC15.
+    HC5_SIMPLE_CORES = {"CVM", "ED", "NL"}
     HC5_GM_GRM = {"GM", "GRM"}
 
     GM_GRM_CAPS = {
@@ -581,10 +581,10 @@ def allocate_timetable(
                     )
 
             # MICU / RCCM
-            # else:
-            #     # Intentionally not capped here.
-            #     # Governed exclusively by HC15 (packs, stages, contiguity).
-            #     pass
+            else:
+                # Intentionally not capped here.
+                # Governed exclusively by HC15 (packs, stages, contiguity).
+                pass
 
     # Hard Constraint 6: Prevent residents from repeating the same elective regardless of hospital
     for resident in residents:


### PR DESCRIPTION
### Summary
- This PR resolves solver infeasibility on solving with the actual datasets. Closes #45. 
- Added support for `GM`/`GRM` cap extension when `MedComm (TTSH)` is completed historically or assigned this year.
- Fixed solver infeasibility by excluding `MICU`/`RCCM` from HC5 core caps and delegating their totals entirely to HC15.
- Clarified ownership and intent of HC5 without changing existing core requirements.

### Problems
- Applying simple core caps to `MICU`, `RCCM` in HC5 conflicted with HC15’s structured, stage-based delivery logic, causing infeasible solves.
- `GM`, `GRM` previously could not exceed base requirements even when `MedComm` was completed or assigned, despite this being a valid training pathway.

### Changes
#### HC5 — Core Caps
- Scoped HC5 to `GM` and `GRM` (with MedComm-dependent caps) and `CVM`, `ED`, `NL` (simple caps)
- Excluded `MICU` and `RCCM` from HC5 (governed exclusively by HC15)
- Added `medcomm_flag`: True if `MedComm (TTSH)` is completed historically or assigned this year. Unlocks higher GM/GRM caps when set.

#### HC15 — `MICU`, `RCCM` by Stage
- No functional change.
- Remains the single source of truth for `MICU`, `RCCM` totals, packs, and stage completion.

#### Why This Works
- Prevents overlapping constraints on `MICU`, `RCCM` by enforcing totals and structure in one place (HC15).
- Allows `GM`, `GRM` flexibility without affecting other cores.
- Preserves all existing numerical requirements.