### PR TITLE
fix: Leaves disappear after editing and saving

### DIFF
--- a/client/src/components/ResidentTimetable.tsx
+++ b/client/src/components/ResidentTimetable.tsx
@@ -93,6 +93,7 @@ const ResidentTimetable: React.FC<Props> = ({
   const { apiResponse, setApiResponse } = useApiResponseContext();
   const [isSaving, setIsSaving] = useState(false);
   const [warnings, setWarnings] = useState<Warning[]>([]);
+  const hasHydratedRef = useRef(false);
 
   // required so that popover does not get "eaten" by the DnD overlay
   const sensors = useSensors(
@@ -131,7 +132,6 @@ const ResidentTimetable: React.FC<Props> = ({
 
     const currentYear = allHistory.filter((h) => h.is_current_year === true);
     const pastYear = allHistory.filter((h) => h.is_current_year === false);
-
     const initialCurrentYearBlockPostings = currentYear.reduce<BlockMap>(
       (m, a) => {
         m[a.month_block] = a;
@@ -406,18 +406,28 @@ const ResidentTimetable: React.FC<Props> = ({
   };
 
   useEffect(() => {
+    // Nothing to hydrate
+    if (!Object.keys(initialCurrentYearBlockPostings).length) return;
+
+    // when timetable is first generated, set it with backend data
+    if (!hasHydratedRef.current) {
+      setCurrentYearBlockPostings(initialCurrentYearBlockPostings);
+      originalBlockPostings.current = initialCurrentYearBlockPostings;
+      hasHydratedRef.current = true;
+      return;
+    }
+
+    // after saving, keep the blocks with leaves
     setCurrentYearBlockPostings(prev => {
-      const merged: BlockMap = { ...prev };
+      const merged: BlockMap = { ...initialCurrentYearBlockPostings };
 
       for (let i = 1; i <= 12; i++) {
-        const incoming = initialCurrentYearBlockPostings[i];
         const existing = prev[i];
 
-        // Always preserve leave blocks
         if (existing?.is_leave) {
           merged[i] = existing;
-        } else if (incoming) {
-          merged[i] = incoming;
+        } else if (editedBlocks.has(i) && existing) {
+          merged[i] = existing;
         }
       }
 

--- a/client/src/components/ResidentTimetable.tsx
+++ b/client/src/components/ResidentTimetable.tsx
@@ -406,7 +406,24 @@ const ResidentTimetable: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    setCurrentYearBlockPostings(initialCurrentYearBlockPostings);
+    setCurrentYearBlockPostings(prev => {
+      const merged: BlockMap = { ...prev };
+
+      for (let i = 1; i <= 12; i++) {
+        const incoming = initialCurrentYearBlockPostings[i];
+        const existing = prev[i];
+
+        // Always preserve leave blocks
+        if (existing?.is_leave) {
+          merged[i] = existing;
+        } else if (incoming) {
+          merged[i] = incoming;
+        }
+      }
+
+      return merged;
+    });
+
     originalBlockPostings.current = initialCurrentYearBlockPostings;
     setEditedBlocks(new Set());
   }, [initialCurrentYearBlockPostings]);


### PR DESCRIPTION
- Fixed the bug where the leave blocks disappear after a user edits and saves timetable block(s)
- Closes #16 

#### Before editing timetable block(s)
<img width="1379" height="566" alt="Screenshot 2026-01-12 at 20 27 10" src="https://github.com/user-attachments/assets/50905166-4ae5-49d1-bcfc-10769cb5fcbd" />

#### After editing and saving timetable block(s)
<img width="1368" height="543" alt="Screenshot 2026-01-12 at 20 27 36" src="https://github.com/user-attachments/assets/2768654f-6be4-4c78-9339-dc67f4142cd0" />

