### PR TITLE
feat: HC18 - Assign elective postings based on elective preference

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -196,14 +196,10 @@ Refer to `# HELPERS` section of the code in [`server/services/posting_allocator.
 - **Example**:
   ```
   ELECTIVE_POSTINGS = [
-    ID (TTSH),
-    Med Onco (TTSH),
-    PMD (TTSH),
-    RAI (TTSH)
-    ...
+    'Endocrine (TTSH)', 'Gastro (TTSH)', 'Haemato (TTSH)', 'ID (TTSH)', 'Med Onco (TTSH)', 'PMD (TTSH)', 'PMD (KTPH)', 'RAI (TTSH)', 'Rehab (TTSH)', 'Renal (TTSH)', 'Endocrine (KTPH)', 'Renal (KTPH)', 'Med Onco (NCC)', 'Derm (NSC)', 'MedComm (TTSH)'
   ]
   ```
-
+  
 #### `ELECTIVE_BASE_CODES`
 
 - Unique list of elective posting codes without variants (without institution names)

--- a/constraints.md
+++ b/constraints.md
@@ -198,6 +198,11 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 - Across each month block, the **total** number of residents assigned to both `GRM (TTSH)` and `MedComm (TTSH)` is equal.
 - This shared quota is decided by the solver. 
 
+#### HC18 - Only assign electives in a resident's elective preferences 
+- For electives, only assign postings among the resident's elective preferences. 
+- For each resident and each block: If a posting is elective and the posting is **not** in the resident’s elective preference list, then that posting must never be assigned to the resident.
+- Exeception: When required to unlock the extended `GM`/`GRM` caps under HC5, allow `MedComm (TTSH)` to be assigned even if it is not in a resident’s elective preferences
+
 ## Soft Constraints
 
 Refer to `# DEFINE SOFT CONSTRAINTS WITH PENALTIES` section of the code in [`server/services/posting_allocator.py`](./server/services/posting_allocator.py).

--- a/constraints.md
+++ b/constraints.md
@@ -201,7 +201,6 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 #### HC18 - Only assign electives in a resident's elective preferences 
 - For electives, only assign postings among the resident's elective preferences. 
 - For each resident and each block: If a posting is elective and the posting is **not** in the resident’s elective preference list, then that posting must never be assigned to the resident.
-- Exeception: When required to unlock the extended `GM` caps under HC5, allow `MedComm (TTSH)` to be assigned even if it is not in a resident’s elective preferences
 
 ## Soft Constraints
 

--- a/constraints.md
+++ b/constraints.md
@@ -122,15 +122,15 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 #### HC5 — Core caps (per resident)
 
 - Do not exceed base core requirements.
-  - `GM` and `GRM` can exceed base requirements if the resident already completed `MedComm (TTSH)` in the past or are assigned `MedComm (TTSH)` in any block this year.
-  | Scenario                | medcomm_flag | GM max | GRM max |
-  | ----------------------- | ------------ | ------ | ------- |
-  | No MedComm              | 0            | 6      | 2       |
-  | MedComm done / assigned | 1            | 12     | 3       |
+  - `GM` can exceed base requirements if the resident already completed `MedComm (TTSH)` in the past or are assigned `MedComm (TTSH)` in any block this year.
+  | Scenario                | medcomm_flag | GM max |
+  | ----------------------- | ------------ | ------ |
+  | No MedComm              | 0            | 6      | 
+  | MedComm done / assigned | 1            | 12     |
 
 - If already met historically, block further assignments of that base. 
-  - Exception: `GM` and `GRM` can exceed base requirements (to max of 12 or 3 respectively) if the resident already completed `MedComm (TTSH)` in the past or are assigned `MedComm (TTSH)` in any block this year.
-- Implies that if a resident has already exceeded the `GM` / `GRM` base cap and has not done `MedComm` historically, then the solver MUST assign `MedComm`.
+  - Exception: `GM` can exceed base requirements (to max of 12) if the resident already completed `MedComm (TTSH)` in the past or are assigned `MedComm (TTSH)` in any block this year.
+- Implies that if a resident has already exceeded the `GM` base cap and has not done `MedComm` historically, then the solver MUST assign `MedComm`.
 
 #### HC6 — Elective repetition
 
@@ -201,7 +201,7 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 #### HC18 - Only assign electives in a resident's elective preferences 
 - For electives, only assign postings among the resident's elective preferences. 
 - For each resident and each block: If a posting is elective and the posting is **not** in the resident’s elective preference list, then that posting must never be assigned to the resident.
-- Exeception: When required to unlock the extended `GM`/`GRM` caps under HC5, allow `MedComm (TTSH)` to be assigned even if it is not in a resident’s elective preferences
+- Exeception: When required to unlock the extended `GM` caps under HC5, allow `MedComm (TTSH)` to be assigned even if it is not in a resident’s elective preferences
 
 ## Soft Constraints
 

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -1020,6 +1020,27 @@ def allocate_timetable(
     for b in blocks[1:]:
         model.Add(pair_total_per_block[b] == ref_total)
 
+    # Hard Constraint 18: For electives, only assign postings from elective preferences
+    logger.info("HC18: Restrict electives to resident preferences")
+    # residents_updated = [r for r in residents if r["mcr"] == "M67879A"]
+    for resident in residents:
+        mcr = resident["mcr"]
+        resident_pref_postings = set(pref_map.get(mcr, {}).values()) 
+        logger.info(
+            f"HC18: {mcr} allowed electives = {sorted(resident_pref_postings)}"
+        )
+
+        for elective in ELECTIVE_POSTINGS:
+            # MedComm allowed if required by HC5
+            if elective == "MedComm (TTSH)" and needs_medcomm.get(mcr, False):
+                logger.info(f"HC18 override: {mcr} allowed MedComm due to GM/GRM cap extension")
+                continue
+
+            # if elective not in preferences, forbid assignment
+            if elective not in resident_pref_postings:
+                for b in blocks:
+                    model.Add(x[mcr][elective][b] == 0)
+
     ###########################################################################
     # DEFINE SOFT CONSTRAINTS WITH PENALTIES
     ###########################################################################

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -1031,11 +1031,6 @@ def allocate_timetable(
         )
 
         for elective in ELECTIVE_POSTINGS:
-            # MedComm allowed if required by HC5
-            if elective == "MedComm (TTSH)" and needs_medcomm.get(mcr, False):
-                logger.info(f"HC18 override: {mcr} allowed MedComm due to GM/GRM cap extension")
-                continue
-
             # if elective not in preferences, forbid assignment
             if elective not in resident_pref_postings:
                 for b in blocks:

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -486,12 +486,12 @@ def allocate_timetable(
 
     # Hard Constraint 5: Ensure core postings are not over-assigned to each resident
     # HC5 only enforces simple caps. MICU and RCCM are governed exclusively by HC15.
-    HC5_SIMPLE_CORES = {"CVM", "ED", "NL"}
-    HC5_GM_GRM = {"GM", "GRM"}
+    HC5_SIMPLE_CORES = {"CVM", "ED", "NL", "GRM"}
+    HC5_GM = {"GM"}
 
     GM_GRM_CAPS = {
-        0: {"GM": CORE_REQUIREMENTS["GM"], "GRM": CORE_REQUIREMENTS["GRM"]},
-        1: {"GM": 12, "GRM": 3},  # with MedComm
+        0: {"GM": CORE_REQUIREMENTS["GM"]},
+        1: {"GM": 12},  # with MedComm
     }
 
     needs_medcomm = {}
@@ -505,17 +505,16 @@ def allocate_timetable(
             resident_progress, posting_info
         )
 
-        # Detect residents who already exceeded base GM/GRM caps
+        # Detect residents who already exceeded base GM caps
         needs_medcomm[mcr] = (
             core_completed.get("GM", 0) > GM_GRM_CAPS[0]["GM"]
-            or core_completed.get("GRM", 0) > GM_GRM_CAPS[0]["GRM"]
         )
 
         # MedComm flag: true if completed historically or assigned this year
         medcomm_flag[mcr] = model.NewBoolVar(f"medcomm_flag[{mcr}]")
 
         if needs_medcomm[mcr]:
-            # Must unlock higher GM/GRM caps
+            # Must unlock higher GM caps
             model.Add(medcomm_flag[mcr] == 1)
 
         # Historical MedComm completion
@@ -558,8 +557,8 @@ def allocate_timetable(
                 for b in blocks
             )
 
-            # extended caps for GM / GRM if medcomm present
-            if base_posting in HC5_GM_GRM:
+            # extended caps for GM if medcomm present
+            if base_posting in HC5_GM:
                 cap_no_medcomm = GM_GRM_CAPS[0][base_posting]
                 cap_with_medcomm = GM_GRM_CAPS[1][base_posting]
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -278,7 +278,7 @@ def group_codes_by_institution(codes: List[str]) -> Dict[str, List[str]]:
 CORE_REQUIREMENTS = {
     # total blocks required for each core posting
     "GM": 6,
-    "GRM": 2,
+    "GRM": 3,
     "CVM": 3,
     "RCCM": 3,
     "MICU": 3,


### PR DESCRIPTION
### New changes  
- Added **HC18**, to only assign postings among the resident's elective preferences. 
- Ensured that for each resident and each block: If a posting is elective and the posting is **not** in the resident’s elective preference list, then that posting must never be assigned to the resident.

### Fixes 
- Fixed **HC5** to increase the core cap of `GrM` to 3. Removed extended cap of `GrM`.

### Issue resolved
- Closes #68 
- Conflicts between HC5 and HC18. If a resident has exceeded the `GRM` caps, he needs to be assigned Medcomm (TTSH) in order to increase the GRM caps, based on HC5. This conflicts with HC18; when the resident did not choose MedComm (TTSH) as one of the elective preferences and hence should not be assigned Medcomm (TTSH)