### PR TITLE
fix: Infeasibility of 12 Jan dataset and inaccurate HCs 

### DIFF
--- a/constraints.md
+++ b/constraints.md
@@ -169,15 +169,7 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 
 - If ED or GRM are present, all ED+GRM blocks must form one contiguous run.
 
-#### HC13 — ED↔GRM↔GM contiguity
-
-- If ED, GRM, and GM all appear, their combined blocks must form one contiguous run.
-
-#### HC14 — (Disabled) Guardrail for ED and GRM
-
-- Force 1 ED and 1 GRM when neither is done historically.
-
-#### HC15 — MICU/RCCM by stage
+#### HC13 — MICU/RCCM by stage
 
 - Stage 1 may optionally deliver pack #1 (1 MICU, 2 RCCM).
 - If pack #1 not done historically, stage 1+2 together must deliver pack #1.
@@ -185,7 +177,7 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 - Stage 3 assigns exactly the remaining MICU and RCCM blocks needed to reach three each after history.
   - 3 MICU + 3 RCCM total (including history)
 
-#### HC16 — Balancing within halves and balancing deviation per posting 
+#### HC14 — Balancing within halves and balancing deviation per posting 
 - Within blocks 1-6 and within blocks 7-12, the user can optionally input how much imbalance is allowed between the maximum and minimum number of residents assigned across 6 blocks. 
   - 0 <= (max - min) <= deviation
 - Else, by default (no input on the balancing deviation), the imbalance is 0. 
@@ -193,11 +185,11 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 - `balancing_deviations`
 - Some postings always have 0 balancing deviation, hence are excluded from the list of postings in the dropdown. 
 
-#### HC17 - Shared quota for `GRM (TTSH)` and `MedComm (TTSH)
+#### HC15 - Shared quota for `GRM (TTSH)` and `MedComm (TTSH)
 - Across each month block, the **total** number of residents assigned to both `GRM (TTSH)` and `MedComm (TTSH)` is equal.
 - This shared quota is decided by the solver. 
 
-#### HC18 - Only assign electives in a resident's elective preferences 
+#### HC16 - Only assign electives in a resident's elective preferences 
 - For electives, only assign postings among the resident's elective preferences. 
 - For each resident and each block: If a posting is elective and the posting is **not** in the resident’s elective preference list, then that posting must never be assigned to the resident.
 

--- a/constraints.md
+++ b/constraints.md
@@ -100,7 +100,6 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 #### HC2 — Posting capacity
 
 - Per-block headcount ≤ `max_residents` minus any slots reserved for leave.
-  - NOTE: If `max_residents=0` in `postings.csv`, it is treated as no quota limit on the maximum number of residents in that posting.
 - `available_capacity = max_residents - leave_reserved_slots`
 - `sum(x[r["mcr"]][p][b] for r in residents) <= available_capacity`
 

--- a/constraints.md
+++ b/constraints.md
@@ -165,13 +165,9 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 - Max three GM blocks in stage 1.
 - Historical GM counts toward the cap.
 
-#### HC12 — ED↔GRM contiguity
-
-- If ED or GRM are present, all ED+GRM blocks must form one contiguous run.
-
-#### HC12 - updated
+#### HC12 - Single block (`ED` or CCR) with 2 blocks (`GM`, `GRM` or `MedComm`)
 - Check within 6 months blocks: Within blocks 1-6 and within blocks 7-12
-- If there are 2 blocks with any of these: `GM`, `GRM` or `MedComm`, then there should be `ED` or any CCR within the 6 months blocks.
+- If there are at least 2 blocks with any of these: `GM`, `GRM` or `MedComm`, then there should be `ED` or any CCR within the 6 months blocks.
 
 #### HC13 — MICU/RCCM by stage
 

--- a/constraints.md
+++ b/constraints.md
@@ -169,6 +169,10 @@ Refer to `# DEFINE HARD CONSTRAINTS` section of the code in [`server/services/po
 
 - If ED or GRM are present, all ED+GRM blocks must form one contiguous run.
 
+#### HC12 - updated
+- Check within 6 months blocks: Within blocks 1-6 and within blocks 7-12
+- If there are 2 blocks with any of these: `GM`, `GRM` or `MedComm`, then there should be `ED` or any CCR within the 6 months blocks.
+
 #### HC13 — MICU/RCCM by stage
 
 - Stage 1 may optionally deliver pack #1 (1 MICU, 2 RCCM).

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -737,28 +737,59 @@ def allocate_timetable(
             model.Add(gm_blocks_count <= gm_cap_remaining)
 
     # Hard Constraint 12: if ED and GRM present, enforce contiguity
+    # Within each 6-month window (1–6, 7–12):
+    # If there are >= 2 blocks of {GM, GRM, MedComm},
+    # then there must be >= 1 block of {ED or any CCR}
+    GROUP_A = ["GM", "GRM", "MedComm"]
+    GROUP_B = ["ED"] + CCR_POSTINGS
+    SIX_MONTH_WINDOWS = [early_blocks, late_blocks]
+
+    def base_posting(text):
+        return (str(text or "").split(" (")[0].strip()).lower()
+
     for resident in residents:
         mcr = resident["mcr"]
 
-        # build one BoolVar per block: 1 if block b is ED or GRM, else 0
-        M = []
-        for b in blocks:
-            Mb = model.NewBoolVar(f"{mcr}_ED_GRM_at_block_{b}")
-            # exactly one posting per block, so sum(x for ED+GRM) == Mb
-            model.Add(sum(x[mcr][p][b] for p in ED_codes + GRM_codes) == Mb)
-            M.append(Mb)
+        for w_idx, window in enumerate(SIX_MONTH_WINDOWS):
+            group_a_count = model.NewIntVar(
+                0, len(window),
+                f"{mcr}_HC12_groupA_count_window_{w_idx}"
+            )
+            model.Add(
+                group_a_count ==
+                sum(
+                    x[mcr][p][b]
+                    for b in window
+                    for p in x[mcr]
+                    if base_posting(p) in GROUP_A
+                )
+            )
 
-        # states: 0 = before, 1 = in-run, 2 = after
-        transitions = [
-            (0, 0, 0),
-            (0, 1, 1),
-            (1, 1, 1),
-            (1, 0, 2),
-            (2, 0, 2),
-            # no (2,1,…) so no re-entry
-        ]
-        model.AddAutomaton(M, 0, [0, 1, 2], transitions)
+            # Bool: group_a_count >= 2
+            has_two_group_a = model.NewBoolVar(
+                f"{mcr}_HC12_has_two_groupA_window_{w_idx}"
+            )
+            model.Add(group_a_count >= 2).OnlyEnforceIf(has_two_group_a)
+            model.Add(group_a_count <= 1).OnlyEnforceIf(has_two_group_a.Not())
 
+            # Count Group B blocks in this window
+            group_b_count = model.NewIntVar(
+                0, len(window),
+                f"{mcr}_HC12_groupB_count_window_{w_idx}"
+            )
+            model.Add(
+                group_b_count ==
+                sum(
+                    x[mcr][p][b]
+                    for b in window
+                    for p in x[mcr]
+                    if base_posting(p) in GROUP_B
+                )
+            )
+
+            # Enforce implication: if >=2 Group A → >=1 Group B
+            model.Add(group_b_count >= 1).OnlyEnforceIf(has_two_group_a)
+            
     # Hard Constraint 13: enforce MICU/RCCM minimum requirements by career stage
     micu_rccm_pack_shortfall_flags: List[cp_model.BoolVar] = []
     for resident in residents:

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -756,42 +756,7 @@ def allocate_timetable(
         ]
         model.AddAutomaton(M, 0, [0, 1, 2], transitions)
 
-    # Hard Constraint 13: if ED + GRM + GM present, enforce contiguity
-    for resident in residents:
-        mcr = resident["mcr"]
-
-        # build one BoolVar per block: 1 if block b is ED, GRM or GM, else 0
-        B = []
-        for b in blocks:
-            Bb = model.NewBoolVar(f"{mcr}_bundle_at_{b}")
-            model.Add(sum(x[mcr][p][b] for p in ED_codes + GRM_codes + GM_codes) == Bb)
-            B.append(Bb)
-
-        # states: 0 = before, 1 = in-run, 2 = after
-        transitions = [
-            (0, 0, 0),
-            (0, 1, 1),
-            (1, 1, 1),
-            (1, 0, 2),
-            (2, 0, 2),
-        ]
-        model.AddAutomaton(B, 0, [0, 1, 2], transitions)
-
-    # Hard Constraint 14: enforce 1 ED and 1 GRM SELECTION if BOTH not done before
-    # for resident in residents:
-    #     mcr = resident["mcr"]
-    #     progress = get_core_blocks_completed(
-    #         posting_progress.get(mcr, {}), posting_info
-    #     )
-    #     # have they already finished either ED or GRM?
-    #     done_ED = progress.get("ED", 0) >= CORE_REQUIREMENTS.get("ED", 0)
-    #     done_GRM = progress.get("GRM", 0) >= CORE_REQUIREMENTS.get("GRM", 0)
-
-    #     if not (done_ED or done_GRM):
-    #         model.Add(sum(selection_flags[mcr][p] for p in ED_codes) == 1)
-    #         model.Add(sum(selection_flags[mcr][p] for p in GRM_codes) == 1)
-
-    # Hard Constraint 15: enforce MICU/RCCM minimum requirements by career stage
+    # Hard Constraint 13: enforce MICU/RCCM minimum requirements by career stage
     micu_rccm_pack_shortfall_flags: List[cp_model.BoolVar] = []
     for resident in residents:
         mcr = resident["mcr"]
@@ -930,7 +895,7 @@ def allocate_timetable(
             model.Add(micu_blocks == micu_needed)
             model.Add(rccm_blocks == rccm_needed)
 
-    # Hard Constraint 16: ensure postings are not imbalanced within each half of the year
+    # Hard Constraint 14: ensure postings are not imbalanced within each half of the year
     for p in posting_codes:
         if p == "GRM (TTSH)" or p == "MedComm (TTSH)":
             continue
@@ -976,7 +941,7 @@ def allocate_timetable(
             model.AddMaxEquality(max_in_half, assignments)
             model.Add(max_in_half - min_in_half <= delta)
 
-    # Hard Constraint 17: Shared monthly quota for GRM (TTSH) and MedComm (TTSH)
+    # Hard Constraint 15: Shared monthly quota for GRM (TTSH) and MedComm (TTSH)
     grm_cap = posting_info["GRM (TTSH)"]["max_residents"]
     medcomm_cap = posting_info["MedComm (TTSH)"]["max_residents"]
 
@@ -1007,9 +972,7 @@ def allocate_timetable(
     for b in blocks[1:]:
         model.Add(pair_total_per_block[b] == ref_total)
 
-    # Hard Constraint 18: For electives, only assign postings from elective preferences
-    logger.info("HC18: Restrict electives to resident preferences")
-    # residents_updated = [r for r in residents if r["mcr"] == "M67879A"]
+    # Hard Constraint 16: For electives, only assign postings from elective preferences
     for resident in residents:
         mcr = resident["mcr"]
         resident_pref_postings = set(pref_map.get(mcr, {}).values()) 

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -677,6 +677,9 @@ def allocate_timetable(
     for resident in residents:
         mcr = resident["mcr"]
         for p in posting_codes:
+            # exception for GRM when it is in another run with GM / MedComm
+            if p.split(" (")[0] == "GRM":
+                continue
             # at least one of these must be 0, so you can't have a 1 in Dec and a 1 in Jan
             model.AddBoolOr(
                 [

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -304,7 +304,9 @@ def allocate_timetable(
 
             # bind block-wise variables to posting asgm count variable
             total_blocks = sum(x[mcr][p][b] for b in blocks)
-            model.Add(total_blocks == count * required_duration)
+            
+            # commented out as this should already be enforced by HC3
+            # model.Add(total_blocks == count * required_duration)
 
             # bind selection flags to posting asgm count variable
             flag = selection_flags[mcr][p]
@@ -1119,7 +1121,7 @@ def allocate_timetable(
             core_shortfall[mcr][base] = unmet_flag
 
             # Enforce exact requirement when unmet == 0
-            model.Add(hist_done + assigned == required).OnlyEnforceIf(unmet_flag.Not())
+            model.Add(hist_done + assigned >= required).OnlyEnforceIf(unmet_flag.Not())
 
             # Allow shortfall when unmet == 1
             model.Add(hist_done + assigned <= required - 1).OnlyEnforceIf(unmet_flag)

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -1010,10 +1010,6 @@ def allocate_timetable(
     for resident in residents:
         mcr = resident["mcr"]
         resident_pref_postings = set(pref_map.get(mcr, {}).values()) 
-        logger.info(
-            f"HC18: {mcr} allowed electives = {sorted(resident_pref_postings)}"
-        )
-
         for elective in ELECTIVE_POSTINGS:
             # if elective not in preferences, forbid assignment
             if elective not in resident_pref_postings:

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -875,6 +875,9 @@ def allocate_timetable(
         hist_micu = core_blocks_completed_map.get("MICU", 0)
         hist_rccm = core_blocks_completed_map.get("RCCM", 0)
 
+        if hist_micu == 3 and hist_rccm == 3:
+            continue
+
         if 1 in stages_present and stage1_blocks:
             # by end of 12 months: optionally do first pack (MICU=1 and RCCM=2)
             flag = model.NewBoolVar(f"{mcr}_do_micu_rccm_pack_s1")

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -741,11 +741,11 @@ def allocate_timetable(
     # If there are >= 2 blocks of {GM, GRM, MedComm},
     # then there must be >= 1 block of {ED or any CCR}
     GROUP_A = ["GM", "GRM", "MedComm"]
-    GROUP_B = ["ED"] + CCR_POSTINGS
+    GROUP_B = ["ED", "GM"]
     SIX_MONTH_WINDOWS = [early_blocks, late_blocks]
 
     def base_posting(text):
-        return (str(text or "").split(" (")[0].strip()).lower()
+        return (str(text or "").split(" (")[0].strip()).upper()
 
     for resident in residents:
         mcr = resident["mcr"]
@@ -765,7 +765,6 @@ def allocate_timetable(
                 )
             )
 
-            # Bool: group_a_count >= 2
             has_two_group_a = model.NewBoolVar(
                 f"{mcr}_HC12_has_two_groupA_window_{w_idx}"
             )

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -394,19 +394,24 @@ def allocate_timetable(
 
             model.Add(sum(x[r["mcr"]][p][b] for r in residents) <= available_capacity)
 
-    # Hard Constraint 3: Enforce required_block_duration happens in consecutive blocks
+    # Hard Constraint 3: Enforce required_block_duration in consecutive blocks
+    HC3_EXCEPTION_POSTINGS = {"GRM (TTSH)", "GM (TTSH)", "GRM (KTPH)", "GM (KTPH)"}
     for resident in residents:
         mcr = resident["mcr"]
         for p in posting_codes:
             required_duration = posting_info[p]["required_block_duration"]
-            vars = [x[mcr][p][b] for b in blocks]  # binary sequence
 
+            is_exception = p in HC3_EXCEPTION_POSTINGS
+            if required_duration <= 1 or is_exception:
+                continue  
+
+            vars = [x[mcr][p][b] for b in blocks]  # binary sequence
             if required_duration > 1:
                 # build automaton: Deterministic Finite Automaton (DFA)
                 d = required_duration
                 INIT = 0  # this state means not currently in a run
                 TERM = d + 1  # this state means finished a valid run
-                final_states = {INIT, TERM}
+                final_states = {INIT, TERM, d}
                 transitions = []
 
                 # from state 0, you either stay on state 0 or start a run (to state 1)

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -374,17 +374,6 @@ def allocate_timetable(
             # leaves with posting_code reserve capacity; available slots shrink by that amount
             leave_reserved_slots = leave_quota_usage.get(p, {}).get(b, 0)
 
-            if max_residents == 0:
-                # No quota limit → skip the constraint
-                if leave_reserved_slots:
-                    logger.info(
-                        "No quota for posting %s, but %d slot(s) reserved for leave on block %s",
-                        p,
-                        leave_reserved_slots,
-                        b,
-                    )
-                continue
-
             available_capacity = max_residents - leave_reserved_slots
             if available_capacity < 0:
                 logger.warning(
@@ -949,11 +938,7 @@ def allocate_timetable(
         max_residents = posting_info[p]["max_residents"] 
 
         # ensure balancing deviation is within posting capacity
-        if max_residents == 0:
-            # 0 means unlimited capacity → do not cap deviation
-            delta = max(0, balancing_deviation)
-        else:
-            delta = max(0, min(balancing_deviation, max_residents))
+        delta = max(0, min(balancing_deviation, max_residents))
 
         # update balancing_deviations if delta is non-zero
         if delta > 0:

--- a/server/services/postprocess.py
+++ b/server/services/postprocess.py
@@ -325,18 +325,16 @@ def compute_postprocess(payload: Dict) -> Dict:
             if 1 <= b <= 12:
                 block_filled[b] += 1
 
-        util_per_block = []
-        for block, count in block_filled.items():
-            cap = posting_info[posting_code]["max_residents"]
-            effective_capacity = count if cap == 0 else cap
-            util_per_block.append(
-                {
-                    "month_block": block,
-                    "filled": count,
-                    "capacity": effective_capacity,
-                    "is_over_capacity": count > effective_capacity,
-                }
-            )
+        capacity = int(pinfo.get("max_residents", 0))
+        util_per_block = [
+            {
+                "month_block": block,
+                "filled": count,
+                "capacity": capacity,
+                "is_over_capacity": count > capacity,
+            }
+            for block, count in block_filled.items()
+        ]
 
         posting_util.append(
             {"posting_code": posting_code, "util_per_block": util_per_block}

--- a/server/services/preprocessing.py
+++ b/server/services/preprocessing.py
@@ -394,7 +394,7 @@ def _validate_resident_history_strict(
         is_leave = r.get("is_leave")
 
         # Allow empty posting_code if on leave; otherwise must exist in posting_codes
-        if posting_code:
+        if posting_code and is_leave != 1:
             _require(
                 posting_code in posting_codes,
                 f"Row {idx}: posting_code '{posting_code}' not found in postings CSV",
@@ -503,11 +503,12 @@ def _format_preferences(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     formatted = []
     for row in records:
         posting_code = str(row.get("posting_code") or "").strip()
+        mcr = str(row.get("mcr") or "").strip().upper()
         if not posting_code:
             continue
         formatted.append(
             {
-                "mcr": str(row.get("mcr") or "").strip(),
+                "mcr": mcr,
                 "preference_rank": parse_int(row.get("preference_rank")),
                 "posting_code": posting_code,
             }

--- a/server/services/validate.py
+++ b/server/services/validate.py
@@ -277,10 +277,6 @@ def validate_assignment(payload: Dict[str, Any]) -> Dict[str, Any]:
             cap.setdefault(p, {})[b] = cap.get(p, {}).get(b, 0) + 1
         for p_code, by_b in cap.items():
             max_r = int(posting_info.get(p_code, {}).get("max_residents", 0))
-            
-            # 0 means unlimited → skip capacity validation
-            if max_r == 0:
-                continue
 
             for b, filled in by_b.items():
                 if filled > max_r:


### PR DESCRIPTION
- Fixed interpretation when max_residents = 0, it should mean 0 capacity
- Fixed HC18 to skip this constraint once 3 RCCM and 3 MICU completed historically
- Fixed processing of `mcr` to be case-insensitive
- Removed HC13 and HC14
- Updated HC12 have a better representation of postings: Within 6 blocks, if there are at least 2 blocks with any of these: `GM`, `GRM` or `MedComm`, then there should be `ED` or any CCR within the 6 months blocks.
- Fixed HC3 horizon-ending runs and exception handling: Allow exact-length runs to end at the horizon in HC3 automaton. Skip HC3 enforcement for exception postings like `GM`, `GRM`.

Closes #74 