### PR TITLE
fix: Use solver-chosen SR instead of inferring from schedule

### DIFF
--- a/client/src/components/ResidentTimetable.tsx
+++ b/client/src/components/ResidentTimetable.tsx
@@ -108,6 +108,7 @@ const ResidentTimetable: React.FC<Props> = ({
     postingMap,
     preferenceMap,
     srPreferenceMap,
+    chosenSrBase,
     pastYearBlockPostings,
     initialCurrentYearBlockPostings,
     electiveCounts,
@@ -115,7 +116,6 @@ const ResidentTimetable: React.FC<Props> = ({
     optimisationScoreRaw,
     optimisationScoreNormalised,
     residentIndex,
-    assignedSrPostingCode,
     electivePreferenceBases,
     corePostingBases,
   } = useMemo(() => {
@@ -161,21 +161,11 @@ const ResidentTimetable: React.FC<Props> = ({
         return m;
       }, {});
 
-    const srPreferenceBases = Object.values(srPreferenceMap)
-      .map((base) => base?.trim())
-      .filter((base): base is string => Boolean(base));
+    const chosenSrBase = apiResponse?.chosen_sr_by_resident?.[resident.mcr]?.trim() || undefined;
 
     const electivePreferenceBases = Object.values(preferenceMap)
       .map((code) => code?.split(" (")[0]?.trim())
       .filter((base): base is string => Boolean(base));
-
-    const assignedSrPostingCode = currentYear
-      .filter((h) => !h.is_leave && h.posting_code)
-      .map((h) => h.posting_code as string)
-      .find((code) => {
-        const base = code.split(" (")[0]?.trim();
-        return base && srPreferenceBases.includes(base);
-      });
 
     const electiveCounts = allHistory
       .filter(
@@ -209,14 +199,14 @@ const ResidentTimetable: React.FC<Props> = ({
       postingMap,
       preferenceMap,
       srPreferenceMap,
+      chosenSrBase,
       pastYearBlockPostings,
       initialCurrentYearBlockPostings,
       electiveCounts,
       currentYearItemIds,
       optimisationScoreRaw,
       optimisationScoreNormalised,
-      residentIndex,
-      assignedSrPostingCode,
+      residentIndex,      
       electivePreferenceBases,
       corePostingBases,
     };
@@ -257,10 +247,6 @@ const ResidentTimetable: React.FC<Props> = ({
       "text-sm",
       fulfilled ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"
     );
-
-  const assignedSrBase = assignedSrPostingCode
-    ? assignedSrPostingCode.split(" (")[0]?.trim()
-    : undefined;
 
   // define current evolving state for current year block postings
   const [currentYearBlockPostings, setCurrentYearBlockPostings] =
@@ -792,7 +778,7 @@ const ResidentTimetable: React.FC<Props> = ({
                     ([rank, base]) => {
                       const trimmedBase = base?.trim() ?? "";
                       const isAssignedSr =
-                        assignedSrBase && trimmedBase === assignedSrBase;
+                        chosenSrBase && trimmedBase === chosenSrBase;
                       const isCoreSrBase =
                         trimmedBase.length > 0 &&
                         corePostingBases.has(trimmedBase);
@@ -886,19 +872,19 @@ const ResidentTimetable: React.FC<Props> = ({
                 </TableHeader>
                 <TableBody>
                   {Object.entries(electiveCounts).map(([code, count]) => {
-                    const isAssignedSr =
-                      assignedSrPostingCode && code === assignedSrPostingCode;
+                    const base = code.split(" (")[0].trim();
+                    const isChosenSr = chosenSrBase && base === chosenSrBase;
                     return (
                       <TableRow
                         key={code}
                         className={cn(
-                          isAssignedSr &&
+                          isChosenSr &&
                             "bg-green-50 hover:bg-green-100 font-semibold border border-green-200"
                         )}
                       >
                         <TableCell className="text-center align-middle">
                           {postingMap[code]?.posting_code || code}
-                          {isAssignedSr && (
+                          {isChosenSr && (
                             <Badge className="ml-2 text-xs bg-green-200 text-green-900">
                               Assigned
                             </Badge>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -13,6 +13,7 @@ export interface ApiResponse {
   resident_history: ResidentHistory[];
   resident_preferences: ResidentPreference[];
   resident_sr_preferences: ResidentSrPreference[];
+  chosen_sr_by_resident: Record<string, string>;
   postings: Posting[];
   statistics: Statistics;
 }

--- a/server/main.py
+++ b/server/main.py
@@ -54,6 +54,7 @@ def _build_postprocess_payload(
         "resident_sr_preferences": _deepcopy(
             base_input.get("resident_sr_preferences") or []
         ),
+        "chosen_sr_by_resident": _deepcopy(base_input.get("chosen_sr_by_resident") or []),
         "postings": _deepcopy(base_input.get("postings") or []),
         "weightages": _deepcopy(base_input.get("weightages") or {}),
         "balancing_deviations": _deepcopy(base_input.get("balancing_deviations") or {}),

--- a/server/services/posting_allocator.py
+++ b/server/services/posting_allocator.py
@@ -1700,6 +1700,9 @@ def allocate_timetable(
     if status == cp_model.OPTIMAL or status == cp_model.FEASIBLE:
         logger.info("Model is feasible. Preparing output for post-processing...")
 
+        # the SR chosen by the solver
+        chosen_sr_by_resident = {}
+
         # log chosen SR per resident (if any)
         for resident in residents:
             mcr = resident["mcr"]
@@ -1710,6 +1713,7 @@ def allocate_timetable(
                 if solver.Value(flag):
                     chosen_sr = base_names.get(p, p)
                     break
+            chosen_sr_by_resident[mcr]= chosen_sr
             logger.info("Chosen SR for %s: %s", mcr, chosen_sr or "None")
 
         # extract solver assignments for downstream post-processing
@@ -1763,7 +1767,8 @@ def allocate_timetable(
             "residents": residents,
             "resident_history": resident_history,
             "resident_preferences": resident_preferences,
-            "resident_sr_preferences": resident_sr_preferences,
+            "resident_sr_preferences": resident_sr_preferences, 
+            "chosen_sr_by_resident": chosen_sr_by_resident,
             "postings": postings,
             "weightages": weightages,
             "balancing_deviations": balancing_deviations,

--- a/server/services/postprocess.py
+++ b/server/services/postprocess.py
@@ -16,6 +16,7 @@ def compute_postprocess(payload: Dict) -> Dict:
     resident_history_input: List[Dict] = payload.get("resident_history", [])
     resident_preferences: List[Dict] = payload.get("resident_preferences", [])
     resident_sr_preferences: List[Dict] = payload.get("resident_sr_preferences", [])
+    chosen_sr_by_resident: Dict[str, str] = payload.get("chosen_sr_by_resident", {})
     postings: List[Dict] = payload.get("postings", [])
     weightages: Dict = dict(payload.get("weightages", {}) or {})
     balancing_deviations: Dict = dict(payload.get("balancing_deviations", {}) or {})


### PR DESCRIPTION
- This PR fixes a bug on the dashboard where the frontend was inferring the chosen Senior Residency (SR) by checking whether any scheduled posting happened to match an SR preference.
- Instead, the frontend now reads the solver’s explicit SR decision from the backend, which is the correct source of truth.
- Closes #9

### Backend
- Extracted the solver’s SR decision using `sr_choice_flags`
- Returned a new field in the API response:
```
chosen_sr_by_resident: {
  "<mcr>": "<chosen SR base>"
}
```

### Frontend
- Removed all logic that infers SR from scheduled postings
- Read `chosen_sr_by_resident[mcr]` directly
- Highlighted SR preferences and electives based on the solver-chosen SR
- Clear separation between decision (SR choice) and execution (schedule)
