### PR TITLE
fix: Add frontend validation for HC5 and HC16

### DIFF
--- a/client/src/components/ResidentTimetable.tsx
+++ b/client/src/components/ResidentTimetable.tsx
@@ -107,6 +107,7 @@ const ResidentTimetable: React.FC<Props> = ({
   const {
     postingMap,
     preferenceMap,
+    electivePreferencePostingSet,
     srPreferenceMap,
     chosenSrBase,
     pastYearBlockPostings,
@@ -154,6 +155,10 @@ const ResidentTimetable: React.FC<Props> = ({
         return m;
       }, {});
 
+    const electivePreferencePostingSet = new Set(
+      Object.values(preferenceMap).filter((code): code is string => Boolean(code))
+    );
+
     const srPreferenceMap = (apiResponse?.resident_sr_preferences ?? [])
       .filter((p) => p.mcr === resident.mcr && p.base_posting)
       .reduce<Record<number, string>>((m, p) => {
@@ -198,6 +203,7 @@ const ResidentTimetable: React.FC<Props> = ({
     return {
       postingMap,
       preferenceMap,
+      electivePreferencePostingSet,
       srPreferenceMap,
       chosenSrBase,
       pastYearBlockPostings,
@@ -241,6 +247,8 @@ const ResidentTimetable: React.FC<Props> = ({
 
   const electivesCompleted = resident.unique_electives_completed.length;
   const electiveRequirementMet = electivesCompleted >= ELECTIVE_REQUIREMENT;
+  const hasElectivePreferences =
+    Object.values(preferenceMap).filter((code) => code.trim() !== "").length > 0;
 
   const requirementBadgeClass = (fulfilled: boolean) =>
     cn(
@@ -257,6 +265,30 @@ const ResidentTimetable: React.FC<Props> = ({
   );
   // track which blocks have been edited
   const [editedBlocks, setEditedBlocks] = useState<Set<number>>(new Set());
+
+  // HC5: Calculate GM cap based on MedComm status
+  const medcommHistoricallyDone = resident.core_blocks_completed?.MedComm > 0;
+  const computeGmCapAndCounts = (blockPostings: BlockMap): { gmCap: number; gmCountCurrentYear: number; medcommInCurrentYear: boolean } => {
+    let gmCountCurrentYear = 0;
+    let medcommInCurrentYear = false;
+    for (let i = 1; i <= 12; i++) {
+      const assignment = blockPostings[i];
+      if (!assignment || assignment.is_leave) continue;
+      const base = assignment.posting_code?.split(" (")[0]?.trim();
+      if (base === "GM") gmCountCurrentYear++;
+      if (base === "MedComm") medcommInCurrentYear = true;
+    }
+    const gmCap = medcommHistoricallyDone || medcommInCurrentYear ? 12 : 6;
+    return { gmCap, gmCountCurrentYear, medcommInCurrentYear };
+  };
+
+  const { gmCap, gmCountCurrentYear, medcommInCurrentYear } = useMemo(
+    () => computeGmCapAndCounts(currentYearBlockPostings),
+    [currentYearBlockPostings, medcommHistoricallyDone]
+  );
+
+  const gmHistoricalCount = resident.core_blocks_completed?.GM || 0;
+  const isGmAtCapacity = (gmHistoricalCount + gmCountCurrentYear) >= gmCap;
 
   // boolean value to track if edits were made
   const hasEdits = useMemo(
@@ -611,6 +643,10 @@ const ResidentTimetable: React.FC<Props> = ({
                       const postingAssignment =
                         currentYearBlockPostings[blockNumber];
 
+                      // HC5: Calculate remaining GM slots
+                      const gmRemaining = Math.max(0, gmCap - gmHistoricalCount - gmCountCurrentYear);
+                      const isGmAtCapacity = gmRemaining === 0;
+
                       return (
                         <SortableBlockCell
                           key={month}
@@ -618,6 +654,8 @@ const ResidentTimetable: React.FC<Props> = ({
                           postingAssignment={postingAssignment}
                           edited={editedBlocks.has(blockNumber)}
                           postingMap={postingMap}
+                          allowedElectivePostingCodes={electivePreferencePostingSet}
+                          isGmAtCapacity={isGmAtCapacity}
                           onSelectPosting={(code) =>
                             handleSelectPosting(blockNumber, code)
                           }

--- a/client/src/components/ResidentTimetable.tsx
+++ b/client/src/components/ResidentTimetable.tsx
@@ -247,8 +247,6 @@ const ResidentTimetable: React.FC<Props> = ({
 
   const electivesCompleted = resident.unique_electives_completed.length;
   const electiveRequirementMet = electivesCompleted >= ELECTIVE_REQUIREMENT;
-  const hasElectivePreferences =
-    Object.values(preferenceMap).filter((code) => code.trim() !== "").length > 0;
 
   const requirementBadgeClass = (fulfilled: boolean) =>
     cn(
@@ -265,30 +263,6 @@ const ResidentTimetable: React.FC<Props> = ({
   );
   // track which blocks have been edited
   const [editedBlocks, setEditedBlocks] = useState<Set<number>>(new Set());
-
-  // HC5: Calculate GM cap based on MedComm status
-  const medcommHistoricallyDone = resident.core_blocks_completed?.MedComm > 0;
-  const computeGmCapAndCounts = (blockPostings: BlockMap): { gmCap: number; gmCountCurrentYear: number; medcommInCurrentYear: boolean } => {
-    let gmCountCurrentYear = 0;
-    let medcommInCurrentYear = false;
-    for (let i = 1; i <= 12; i++) {
-      const assignment = blockPostings[i];
-      if (!assignment || assignment.is_leave) continue;
-      const base = assignment.posting_code?.split(" (")[0]?.trim();
-      if (base === "GM") gmCountCurrentYear++;
-      if (base === "MedComm") medcommInCurrentYear = true;
-    }
-    const gmCap = medcommHistoricallyDone || medcommInCurrentYear ? 12 : 6;
-    return { gmCap, gmCountCurrentYear, medcommInCurrentYear };
-  };
-
-  const { gmCap, gmCountCurrentYear, medcommInCurrentYear } = useMemo(
-    () => computeGmCapAndCounts(currentYearBlockPostings),
-    [currentYearBlockPostings, medcommHistoricallyDone]
-  );
-
-  const gmHistoricalCount = resident.core_blocks_completed?.GM || 0;
-  const isGmAtCapacity = (gmHistoricalCount + gmCountCurrentYear) >= gmCap;
 
   // boolean value to track if edits were made
   const hasEdits = useMemo(
@@ -643,10 +617,6 @@ const ResidentTimetable: React.FC<Props> = ({
                       const postingAssignment =
                         currentYearBlockPostings[blockNumber];
 
-                      // HC5: Calculate remaining GM slots
-                      const gmRemaining = Math.max(0, gmCap - gmHistoricalCount - gmCountCurrentYear);
-                      const isGmAtCapacity = gmRemaining === 0;
-
                       return (
                         <SortableBlockCell
                           key={month}
@@ -655,7 +625,6 @@ const ResidentTimetable: React.FC<Props> = ({
                           edited={editedBlocks.has(blockNumber)}
                           postingMap={postingMap}
                           allowedElectivePostingCodes={electivePreferencePostingSet}
-                          isGmAtCapacity={isGmAtCapacity}
                           onSelectPosting={(code) =>
                             handleSelectPosting(blockNumber, code)
                           }

--- a/client/src/components/SortableBlockCell.tsx
+++ b/client/src/components/SortableBlockCell.tsx
@@ -26,7 +26,6 @@ interface SortableBlockCellProps {
   edited: boolean;
   postingMap: Record<string, Posting>;
   allowedElectivePostingCodes?: Set<string>;
-  isGmAtCapacity?: boolean;
   onSelectPosting?: (code: string) => void;
 }
 
@@ -36,7 +35,6 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
   edited,
   postingMap,
   allowedElectivePostingCodes,
-  isGmAtCapacity,
   onSelectPosting,
 }) => {
   const [open, setOpen] = useState<boolean>(false);
@@ -80,6 +78,7 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
       : "bg-green-100 text-green-800";
 
   const selected = postingAssignment?.posting_code ?? "";
+  const selectedBase = selected.split(" (")[0]?.trim();
 
   return (
     <TableCell
@@ -146,8 +145,7 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
                     const core = postings.filter(
                       (p) =>
                         !CCR_POSTINGS.includes(p.posting_code) &&
-                        p.posting_type === "core" &&
-                        !(isGmAtCapacity && p.posting_code.split(" (")[0]?.trim() === "GM")
+                        p.posting_type === "core"
                     );
                     const elective = postings.filter(
                       (p) =>

--- a/client/src/components/SortableBlockCell.tsx
+++ b/client/src/components/SortableBlockCell.tsx
@@ -25,6 +25,8 @@ interface SortableBlockCellProps {
   postingAssignment?: ResidentHistory;
   edited: boolean;
   postingMap: Record<string, Posting>;
+  allowedElectivePostingCodes?: Set<string>;
+  isGmAtCapacity?: boolean;
   onSelectPosting?: (code: string) => void;
 }
 
@@ -33,6 +35,8 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
   postingAssignment,
   edited,
   postingMap,
+  allowedElectivePostingCodes,
+  isGmAtCapacity,
   onSelectPosting,
 }) => {
   const [open, setOpen] = useState<boolean>(false);
@@ -142,12 +146,14 @@ const SortableBlockCell: React.FC<SortableBlockCellProps> = ({
                     const core = postings.filter(
                       (p) =>
                         !CCR_POSTINGS.includes(p.posting_code) &&
-                        p.posting_type === "core"
+                        p.posting_type === "core" &&
+                        !(isGmAtCapacity && p.posting_code.split(" (")[0]?.trim() === "GM")
                     );
                     const elective = postings.filter(
                       (p) =>
                         !CCR_POSTINGS.includes(p.posting_code) &&
-                        p.posting_type === "elective"
+                        p.posting_type === "elective" &&
+                        (allowedElectivePostingCodes?.has(p.posting_code) ?? true)
                     );
                     const others = postings.filter(
                       (p) =>

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -103,8 +103,8 @@ export const SECTIONS = [
         text: "ICU months are staged: pack 1 across years 1 to 2 if not already done, optional pack 2 in year 2, and year 3 completes the remaining months to reach 3 MICU and 3 RCCM total.",
       },
       {
-        label: "HC16 - Balancing within halves",
-        text: "For postings other than GM, ED, and GRM, resident counts are balanced within Jul to Dec and Jan to Jun.",
+        label: "HC16 - Elective preference eligibility",
+        text: "Elective postings can only be assigned if they appear in the resident's elective preference list.",
       },
     ],
   },

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import Body, FastAPI, HTTPException, Request
@@ -13,6 +14,8 @@ from server.services.preprocessing import (
 )
 from server.services.validate import validate_assignment
 from server.utils import MONTH_LABELS
+
+logger = logging.getLogger(__name__)
 
 
 # define a store class for local storage of latest inputs and API response
@@ -157,7 +160,11 @@ async def save(payload: Dict[str, Any] = Body(...)):
 
     validation_result = validate_assignment(validation_payload)
     if not validation_result.get("success"):
+        logger.error(f"[SAVE] Validation failed for MCR {resident_mcr}")
+        logger.error(f"[SAVE] Validation result: {validation_result}")
         return JSONResponse(status_code=400, content=validation_result)
+    
+    logger.info(f"[SAVE] Validation passed for MCR {resident_mcr}")
 
     residents = _deepcopy(store_snapshot.get("residents") or [])
     resident_history = _deepcopy(store_snapshot.get("resident_history") or [])

--- a/server/services/validate.py
+++ b/server/services/validate.py
@@ -188,21 +188,42 @@ def validate_assignment(payload: Dict[str, Any]) -> Dict[str, Any]:
         past_prog = get_posting_progress(past_only, posting_info).get(mcr, {})
 
         core_completed_hist = get_core_blocks_completed(past_prog, posting_info)
+        
+        # Check MedComm separately (it's an elective, not in CORE_REQUIREMENTS)
+        medcomm_completed_hist = any(
+            _base_of(p) == "MedComm" and details.get("blocks_completed", 0) > 0
+            for p, details in past_prog.items()
+        )
+        
         base_counts_current_year: Dict[str, int] = {}
+        medcomm_assigned_current_year = False
         for _, info in by_block.items():
-            if info["is_leave"]: # exclude leave postings in block count 
+            if info["is_leave"]:  # exclude leave postings in block count
                 continue
             code = info["posting_code"]
             base = _base_of(code)
+            
+            # Check for MedComm assignment (regardless of posting_type)
+            if base == "MedComm":
+                medcomm_assigned_current_year = True
+            
             if posting_info.get(code, {}).get("posting_type") == "core":
                 base_counts_current_year[base] = base_counts_current_year.get(base, 0) + 1
+
+        gm_cap = 12 if (medcomm_completed_hist or medcomm_assigned_current_year) else int(CORE_REQUIREMENTS.get("GM", 0))
+
         for base, required in CORE_REQUIREMENTS.items():
             hist_done = int(core_completed_hist.get(base, 0))
             current_year_assigned = int(base_counts_current_year.get(base, 0))
-            if hist_done + current_year_assigned > int(required):
+            cap = gm_cap if base == "GM" else int(required)
+            if hist_done + current_year_assigned > cap:
+                if base == "GM":
+                    cap_note = " (GM cap is 12 when MedComm is completed/assigned)"
+                else:
+                    cap_note = ""
                 add_warning(
                     "HC5",
-                    f"{base}: exceeds total month requirement (completed: {hist_done} + assigned: {current_year_assigned} > required: {required})",
+                    f"{base}: exceeds total month requirement (completed: {hist_done} + assigned: {current_year_assigned} > cap: {cap}){cap_note}",
                 )
 
         # HC6: electives cannot repeat by base posting

--- a/server/services/validate.py
+++ b/server/services/validate.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Tuple
+import logging
 
 from server.utils import (
     get_posting_progress,
@@ -9,6 +10,8 @@ from server.utils import (
     CCR_POSTINGS,
     MONTH_LABELS,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _base_of(code: str) -> str:
@@ -31,6 +34,11 @@ def validate_assignment(payload: Dict[str, Any]) -> Dict[str, Any]:
     resident_history = payload.get("resident_history") or []
     postings = payload.get("postings") or []
     resident_preferences = payload.get("resident_preferences") or []
+
+    logger.info(f"[VALIDATE] Starting validation for MCR: {mcr}")
+    logger.info(f"[VALIDATE] Current year blocks: {current_year}")
+    logger.info(f"[VALIDATE] Total residents in payload: {len(residents)}")
+    logger.info(f"[VALIDATE] Total postings available: {len(postings)}")
 
     warnings: List[Dict[str, str]] = []
 
@@ -197,33 +205,59 @@ def validate_assignment(payload: Dict[str, Any]) -> Dict[str, Any]:
         
         base_counts_current_year: Dict[str, int] = {}
         medcomm_assigned_current_year = False
-        for _, info in by_block.items():
-            if info["is_leave"]:  # exclude leave postings in block count
-                continue
+        logger.info(f"[HC5] Processing blocks for leave check and core counting:")
+        for block_num, info in by_block.items():
+            # Normalize is_leave to boolean (handle both bool and string representations)
+            is_leave_value = info.get("is_leave")
+            if isinstance(is_leave_value, str):
+                is_leave = is_leave_value.lower() in ('true', '1', 'yes')
+            else:
+                is_leave = bool(is_leave_value)
+            
             code = info["posting_code"]
             base = _base_of(code)
+            logger.debug(f"[HC5]   Block {block_num}: code={code}, base={base}, is_leave_raw={repr(is_leave_value)}, is_leave_normalized={is_leave}")
+            
+            if is_leave:  # exclude leave postings in block count
+                logger.debug(f"[HC5]     → Skipping (leave block)")
+                continue
             
             # Check for MedComm assignment (regardless of posting_type)
             if base == "MedComm":
                 medcomm_assigned_current_year = True
+                logger.debug(f"[HC5]     → MedComm detected")
             
-            if posting_info.get(code, {}).get("posting_type") == "core":
+            # Count all postings with bases in CORE_REQUIREMENTS (not just those marked as posting_type="core")
+            if base in CORE_REQUIREMENTS:
                 base_counts_current_year[base] = base_counts_current_year.get(base, 0) + 1
+                logger.debug(f"[HC5]     → Counting {base} (now {base_counts_current_year[base]} blocks)")
+
+        logger.info(f"[HC5] MCR: {mcr}")
+        logger.info(f"[HC5] Blocks processed: {by_block}")
+        logger.info(f"[HC5] base_counts_current_year: {base_counts_current_year}")
+        logger.info(f"[HC5] medcomm_completed_hist: {medcomm_completed_hist}, medcomm_assigned_current_year: {medcomm_assigned_current_year}")
 
         gm_cap = 12 if (medcomm_completed_hist or medcomm_assigned_current_year) else int(CORE_REQUIREMENTS.get("GM", 0))
+        logger.info(f"[HC5] GM cap: {gm_cap}")
 
         for base, required in CORE_REQUIREMENTS.items():
             hist_done = int(core_completed_hist.get(base, 0))
             current_year_assigned = int(base_counts_current_year.get(base, 0))
             cap = gm_cap if base == "GM" else int(required)
-            if hist_done + current_year_assigned > cap:
+            total = hist_done + current_year_assigned
+            
+            logger.info(f"[HC5] {base}: hist_done={hist_done}, current_year_assigned={current_year_assigned}, cap={cap}, total={total}")
+            
+            if total > cap:
                 if base == "GM":
                     cap_note = " (GM cap is 12 when MedComm is completed/assigned)"
                 else:
                     cap_note = ""
+                warning_msg = f"{base}: exceeds total month requirement (completed: {hist_done} + assigned: {current_year_assigned} > cap: {cap}){cap_note}"
+                logger.warning(f"[HC5] VIOLATION: {warning_msg}")
                 add_warning(
                     "HC5",
-                    f"{base}: exceeds total month requirement (completed: {hist_done} + assigned: {current_year_assigned} > cap: {cap}){cap_note}",
+                    warning_msg,
                 )
 
         # HC6: electives cannot repeat by base posting


### PR DESCRIPTION
Closes #98, #104

### HC5
- When editing the sortable block, the number of GM (TTSH) allowed is based on HC5
- If editing a non-GM block and have remaining GM capacity, then GM option is shown
- Only non-GM blocks will have GM hidden when the cap is reached

<img width="1196" height="362" alt="Screenshot 2026-03-05 at 18 48 19" src="https://github.com/user-attachments/assets/415e12ac-269f-4c6b-abe3-79bf90d5d9cc" />
<img width="1204" height="519" alt="Screenshot 2026-03-05 at 18 48 55" src="https://github.com/user-attachments/assets/d2fa0655-4ca1-4c6a-ba35-31bb265c3409" />

another example: 
<img width="1196" height="591" alt="Screenshot 2026-03-05 at 18 50 23" src="https://github.com/user-attachments/assets/f7751760-6f1b-42a8-bcb2-b06859bef446" />


### HC16
- When the user edits a sortable block, the user can only choose from a list of electives in the resident's list of elective preferences

<img width="233" alt="Screenshot 2026-03-04 at 21 30 23" src="https://github.com/user-attachments/assets/8c95f01d-e0de-4cb7-9287-8d537f8fccc7" />


<img width="1182" height="468" alt="Screenshot 2026-03-05 at 11 26 39" src="https://github.com/user-attachments/assets/8ad50dab-994f-4631-963c-ab127acadb2b" />
